### PR TITLE
Addressing issue #16

### DIFF
--- a/include/xhal/rpc/calibration_routines.h
+++ b/include/xhal/rpc/calibration_routines.h
@@ -4,6 +4,6 @@
 #include "xhal/rpc/utils.h"
 
 DLLEXPORT uint32_t ttcGenConf(uint32_t L1Ainterval, uint32_t pulseDelay);
-DLLEXPORT uint32_t genScan(uint32_t nevts, uint32_t ohN, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep, uint32_t ch, uint32_t enCal, uint32_t mask, char * scanReg);
+DLLEXPORT uint32_t genScan(uint32_t nevts, uint32_t ohN, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep, uint32_t ch, uint32_t enCal, uint32_t mask, char * scanReg, uint32_t * result);
 
 #endif

--- a/python/reg_interface/test.py
+++ b/python/reg_interface/test.py
@@ -49,7 +49,7 @@ ttcGenConf.argtypes = [c_uint, c_uint]
 
 genScan = lib.genScan
 genScan.restype = c_uint
-genScan.argtypes = [c_uint, c_uint, c_uint, c_uint, c_uint, c_uint, c_uint, c_uint, c_char_p]
+genScan.argtypes = [c_uint, c_uint, c_uint, c_uint, c_uint, c_uint, c_uint, c_uint, c_char_p, POINTER(c_uint32)]
 
 confVFAT = lib.configureVFAT3s
 confVFAT.restype = c_uint
@@ -89,6 +89,8 @@ def main():
   mask = 0xF65F7E
   scanReg = "LATENCY"
   confVFAT(ohN,mask)
+  res_size = (dacMax-dacMin+1)/dacStep
+  res = (c_uint * res_size)()
   genScan(nevts, ohN, dacMin, dacMax, dacStep, ch, enCal, mask, scanReg)
 
   #getRegInfo("GEM_AMC.GEM_SYSTEM.BOARD_ID")

--- a/src/common/rpc_manager/calibration_routines.cc
+++ b/src/common/rpc_manager/calibration_routines.cc
@@ -25,7 +25,7 @@ DLLEXPORT uint32_t ttcGenConf(uint32_t L1Ainterval, uint32_t pulseDelay)
 /***
  * @brief run a generic scan routine
  */
-DLLEXPORT uint32_t genScan(uint32_t nevts, uint32_t ohN, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep, uint32_t ch, uint32_t enCal, uint32_t mask, char * scanReg)
+DLLEXPORT uint32_t genScan(uint32_t nevts, uint32_t ohN, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep, uint32_t ch, uint32_t enCal, uint32_t mask, char * scanReg, uint32_t * result)
 {
     req = wisc::RPCMsg("calibration_routines.genScan");
 
@@ -52,7 +52,7 @@ DLLEXPORT uint32_t genScan(uint32_t nevts, uint32_t ohN, uint32_t dacMin, uint32
         return 1;
     }
     const uint32_t size = (dacMax - dacMin+1)*24/dacStep;
-    uint32_t* result = new uint32_t[size];
+    //uint32_t* result = new uint32_t[size];
     if (rsp.get_key_exists("data")) {
         ASSERT(rsp.get_word_array_size("data") == size);
         rsp.get_word_array("data", result); 
@@ -60,6 +60,7 @@ DLLEXPORT uint32_t genScan(uint32_t nevts, uint32_t ohN, uint32_t dacMin, uint32
         printf("No data key found");
         return 1;
     } 
+    /*
     FILE *f = fopen("file.txt", "w");
     if (f == NULL)
     {
@@ -75,5 +76,6 @@ DLLEXPORT uint32_t genScan(uint32_t nevts, uint32_t ohN, uint32_t dacMin, uint32
             fprintf(f,"%d    %d    %d    %d\n",i,result[i*vfatSize+j]&0xFFFF,dacMin+j*dacStep,(result[i*vfatSize+j]>>16)&0xFFFF);
         } 
     }
+    */
     return 0;
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Implementing flattened array return in genScan instead of text file creation
Addressing https://github.com/cms-gem-daq-project/xhal/issues/16

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->

Required for seamless integration into the scan routines

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

It wasn't tested although I'm pretty sure from my previous experience that it will work. 
Some things to pay attention: 

- test.py shows an example how to use
- it is user responsibility to check if the array size will be an integer number (i.e. (scanMax-scanMin+1)/scanStep is an integer number

### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->