### PR TITLE
New Feature: Keyword readAddress prints corresponding node name

### DIFF
--- a/python/reg_interface/reg_interface.py
+++ b/python/reg_interface/reg_interface.py
@@ -367,6 +367,7 @@ class Prompt(Cmd):
             return
         if reg is not None: 
             address = reg.real_address
+            print hex(address),'\t node: ', reg.name
             print hex(address),'\t',readAddress(address)
         else:
             print args,'not found!' 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The keyword `readAddress` now prints the corresponding node name in addition to the read back value.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
Provides a debugging tool, if we see something like:
```
read memsvc error: Bus error accessing 0x65400208
```
In `/var/log/remote/eagleXX/messages.log` it would be helpful to know what node name this hex address corresponds to.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

```
[dorney@cosmicstandtif]~/scratch0/CMS_GEM/CMS_GEM_DAQ/xhal/xhal/python/reg_interface% python reg_interface.py
Parsing /afs/cern.ch/user/d/dorney/scratch0/CMS_GEM/CMS_GEM_DAQ/xhal/xhal/etc/gem_amc_top.xml ...
connect eagle26Starting CTP7 Register Command Line Interface. Please connect to CTP7 using connect <hostname> command
CTP7 > connect eagle26
eagle26 > readAddress 0x654004b0
0x654004b0 	 node:  GEM_AMC.OH.OH0.GEB.VFATS.VFAT1.VFATChannels.ChanReg27
0x654004b0 	0xdeaddead
```
Note here `OH0` does not exist (which would why it would trigger a read bus error).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
