### PR TITLE
 New Feature: ultra scan modules for v2b electronics

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,17 @@
 XHAL interface library
 
 Developers documentation is generated with Doxygen and can be found under doc/
+
+# Compilation Instructions
+
+To compile xhal RPC modules execute:
+
+```
+make rpc
+```
+
+To compile CTP7 RPC libraries first compile `$BUILD_HOME/ctp7_modules` then execute:
+
+```
+make clean -f Makefile_ctp7
+```

--- a/include/xhal/rpc/calibration_routines.h
+++ b/include/xhal/rpc/calibration_routines.h
@@ -3,9 +3,9 @@
 
 #include "xhal/rpc/utils.h"
 
-DLLEXPORT uint32_t ttcGenToggle(uint32_t ohN, bool bRun);
+DLLEXPORT uint32_t ttcGenToggle(uint32_t ohN, bool enable);
 DLLEXPORT uint32_t ttcGenConf(uint32_t ohN, uint32_t mode, uint32_t type, uint32_t pulseDelay,
-        uint32_t L1Ainterval, uint32_t nPulses, bool bRun);
+        uint32_t L1Ainterval, uint32_t nPulses, bool enable);
 DLLEXPORT uint32_t genScan(uint32_t nevts, uint32_t ohN, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep,
         uint32_t ch, uint32_t enCal, uint32_t mask, char * scanReg, bool useUltra, uint32_t * result);
 

--- a/include/xhal/rpc/calibration_routines.h
+++ b/include/xhal/rpc/calibration_routines.h
@@ -3,7 +3,10 @@
 
 #include "xhal/rpc/utils.h"
 
-DLLEXPORT uint32_t ttcGenConf(uint32_t L1Ainterval, uint32_t pulseDelay);
-DLLEXPORT uint32_t genScan(uint32_t nevts, uint32_t ohN, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep, uint32_t ch, uint32_t enCal, uint32_t mask, char * scanReg, uint32_t * result);
+DLLEXPORT uint32_t ttcGenToggle(uint32_t ohN, bool bRun);
+DLLEXPORT uint32_t ttcGenConf(uint32_t ohN, uint32_t mode, uint32_t type, uint32_t pulseDelay,
+        uint32_t L1Ainterval, uint32_t nPulses, bool bRun);
+DLLEXPORT uint32_t genScan(uint32_t nevts, uint32_t ohN, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep,
+        uint32_t ch, uint32_t enCal, uint32_t mask, char * scanReg, bool useUltra, uint32_t * result);
 
 #endif

--- a/include/xhal/rpc/calibration_routines.h
+++ b/include/xhal/rpc/calibration_routines.h
@@ -7,6 +7,6 @@ DLLEXPORT uint32_t ttcGenToggle(uint32_t ohN, bool enable);
 DLLEXPORT uint32_t ttcGenConf(uint32_t ohN, uint32_t mode, uint32_t type, uint32_t pulseDelay,
         uint32_t L1Ainterval, uint32_t nPulses, bool enable);
 DLLEXPORT uint32_t genScan(uint32_t nevts, uint32_t ohN, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep,
-        uint32_t ch, uint32_t enCal, uint32_t mask, char * scanReg, bool useUltra, uint32_t * result);
+        uint32_t ch, bool useCalPulse, uint32_t mask, char * scanReg, bool useUltra, uint32_t * result);
 
 #endif

--- a/include/xhal/rpc/optohybrid.h
+++ b/include/xhal/rpc/optohybrid.h
@@ -10,5 +10,6 @@ DLLEXPORT uint32_t configureScanModule(uint32_t ohN, uint32_t vfatN, uint32_t sc
 DLLEXPORT uint32_t printScanConfiguration(uint32_t ohN, bool useUltra);
 DLLEXPORT uint32_t startScanModule(uint32_t ohN, bool useUltra);
 DLLEXPORT uint32_t getUltraScanResults(uint32_t ohN, uint32_t nevts, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep, uint32_t * result);
+DLLEXPORT uint32_t stopCalPulse2AllChannels(uint32_t ohN, uint32_t mask, uint32_t ch_min, uint32_t ch_max);
 
 #endif

--- a/include/xhal/rpc/optohybrid.h
+++ b/include/xhal/rpc/optohybrid.h
@@ -5,5 +5,10 @@
 
 DLLEXPORT uint32_t broadcastRead(uint32_t ohN, char * regName, uint32_t vfatMask, uint32_t * result);
 DLLEXPORT uint32_t broadcastWrite(uint32_t ohN, char * regName, uint32_t value, uint32_t vfatMask);
+DLLEXPORT uint32_t configureScanModule(uint32_t ohN, uint32_t vfatN, uint32_t scanmode, bool useUltra,
+        uint32_t vfatMask, uint32_t ch, uint32_t nevts, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep);
+DLLEXPORT uint32_t printScanConfiguration(uint32_t ohN, bool useUltra);
+DLLEXPORT uint32_t startScanModule(uint32_t ohN, bool useUltra);
+DLLEXPORT uint32_t getUltraScanResults(uint32_t ohN, uint32_t nevts, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep, uint32_t * result);
 
 #endif

--- a/src/common/rpc_manager/calibration_routines.cc
+++ b/src/common/rpc_manager/calibration_routines.cc
@@ -1,16 +1,37 @@
 #include "xhal/rpc/calibration_routines.h"
 
+DLLEXPORT uint32_t ttcGenToggle(uint32_t ohN, bool bRun){
+    wisc::RPCSvc* rpc_loc = getRPCptr();
+    req = wisc::RPCMsg("calibration_routines.ttcGenToggle");
+    req.set_word("ohN", ohN);
+    req.set_word("bRun", bRun);
+    try {
+        rsp = rpc_loc->call_method(req);
+    }
+    STANDARD_CATCH;
+
+    if (rsp.get_key_exists("error")) {
+        return 1;
+    }
+    return 0;
+} //End ttcGenToggle(...)
+
 /***
  * @brief configure TTC generator
  */
-DLLEXPORT uint32_t ttcGenConf(uint32_t L1Ainterval, uint32_t pulseDelay)
+DLLEXPORT uint32_t ttcGenConf(uint32_t ohN, uint32_t mode, uint32_t type, uint32_t pulseDelay, uint32_t L1Ainterval, uint32_t nPulses, bool bRun)
 {
     wisc::RPCSvc* rpc_loc = getRPCptr();
     //wisc::RPCMsg req_loc, rsp_loc;
     //req_loc = wisc::RPCMsg("calibration_routines.ttcGenConf");
     req = wisc::RPCMsg("calibration_routines.ttcGenConf");
-    req.set_word("L1Ainterval", L1Ainterval);
+    req.set_word("ohN", ohN);
+    req.set_word("mode", mode);
+    req.set_word("type", type);
     req.set_word("pulseDelay", pulseDelay);
+    req.set_word("L1Ainterval", L1Ainterval);
+    req.set_word("nPulses", nPulses);
+    req.set_word("bRun", bRun);
     try {
         rsp = rpc_loc->call_method(req);
     }
@@ -25,7 +46,7 @@ DLLEXPORT uint32_t ttcGenConf(uint32_t L1Ainterval, uint32_t pulseDelay)
 /***
  * @brief run a generic scan routine
  */
-DLLEXPORT uint32_t genScan(uint32_t nevts, uint32_t ohN, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep, uint32_t ch, uint32_t enCal, uint32_t mask, char * scanReg, uint32_t * result)
+DLLEXPORT uint32_t genScan(uint32_t nevts, uint32_t ohN, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep, uint32_t ch, uint32_t enCal, uint32_t mask, char * scanReg, bool useUltra, uint32_t * result)
 {
     req = wisc::RPCMsg("calibration_routines.genScan");
 
@@ -37,9 +58,11 @@ DLLEXPORT uint32_t genScan(uint32_t nevts, uint32_t ohN, uint32_t dacMin, uint32
     req.set_word("ch", ch);
     req.set_word("enCal", enCal);
     req.set_word("mask", mask);
+    if(useUltra){
+        req.set_word("useUltra", useUltra);
+    }
     req.set_string("scanReg", std::string(scanReg));
 
-    //std::shared_ptr<wisc::RPCSvc> rpc_loc = getRPCptr();
     wisc::RPCSvc* rpc_loc = getRPCptr();
 
     try {
@@ -52,30 +75,13 @@ DLLEXPORT uint32_t genScan(uint32_t nevts, uint32_t ohN, uint32_t dacMin, uint32
         return 1;
     }
     const uint32_t size = (dacMax - dacMin+1)*24/dacStep;
-    //uint32_t* result = new uint32_t[size];
     if (rsp.get_key_exists("data")) {
         ASSERT(rsp.get_word_array_size("data") == size);
-        rsp.get_word_array("data", result); 
+        rsp.get_word_array("data", result);
     } else {
         printf("No data key found");
         return 1;
-    } 
-    /*
-    FILE *f = fopen("file.txt", "w");
-    if (f == NULL)
-    {
-        printf("Error opening file!\n");
-        exit(1);
     }
-    fprintf(f, "vfatN/I:nEvents/I:dacVal/I:nHits/I\n");
-    uint32_t vfatSize = (dacMax-dacMin+1)/dacStep;
-    for (unsigned int i = 0; i<24; i++)
-    {
-        for (unsigned int j = 0; j<vfatSize; j++)
-        {
-            fprintf(f,"%d    %d    %d    %d\n",i,result[i*vfatSize+j]&0xFFFF,dacMin+j*dacStep,(result[i*vfatSize+j]>>16)&0xFFFF);
-        } 
-    }
-    */
+
     return 0;
 }

--- a/src/common/rpc_manager/calibration_routines.cc
+++ b/src/common/rpc_manager/calibration_routines.cc
@@ -70,7 +70,7 @@ DLLEXPORT uint32_t ttcGenConf(uint32_t ohN, uint32_t mode, uint32_t type, uint32
 /***
  * @brief run a generic scan routine
  */
-DLLEXPORT uint32_t genScan(uint32_t nevts, uint32_t ohN, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep, uint32_t ch, uint32_t useCalPulse, uint32_t mask, char * scanReg, bool useUltra, uint32_t * result)
+DLLEXPORT uint32_t genScan(uint32_t nevts, uint32_t ohN, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep, uint32_t ch, bool useCalPulse, uint32_t mask, char * scanReg, bool useUltra, uint32_t * result)
 {
     req = wisc::RPCMsg("calibration_routines.genScan");
 

--- a/src/common/rpc_manager/calibration_routines.cc
+++ b/src/common/rpc_manager/calibration_routines.cc
@@ -70,7 +70,7 @@ DLLEXPORT uint32_t ttcGenConf(uint32_t ohN, uint32_t mode, uint32_t type, uint32
 /***
  * @brief run a generic scan routine
  */
-DLLEXPORT uint32_t genScan(uint32_t nevts, uint32_t ohN, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep, uint32_t ch, uint32_t enCal, uint32_t mask, char * scanReg, bool useUltra, uint32_t * result)
+DLLEXPORT uint32_t genScan(uint32_t nevts, uint32_t ohN, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep, uint32_t ch, uint32_t useCalPulse, uint32_t mask, char * scanReg, bool useUltra, uint32_t * result)
 {
     req = wisc::RPCMsg("calibration_routines.genScan");
 
@@ -80,7 +80,7 @@ DLLEXPORT uint32_t genScan(uint32_t nevts, uint32_t ohN, uint32_t dacMin, uint32
     req.set_word("dacMax", dacMax);
     req.set_word("dacStep", dacStep);
     req.set_word("ch", ch);
-    req.set_word("enCal", enCal);
+    req.set_word("useCalPulse", useCalPulse);
     req.set_word("mask", mask);
     if(useUltra){
         req.set_word("useUltra", useUltra);

--- a/src/common/rpc_manager/calibration_routines.cc
+++ b/src/common/rpc_manager/calibration_routines.cc
@@ -1,10 +1,15 @@
 #include "xhal/rpc/calibration_routines.h"
 
-DLLEXPORT uint32_t ttcGenToggle(uint32_t ohN, bool bRun){
+DLLEXPORT uint32_t ttcGenToggle(uint32_t ohN, bool enable){
+    /*
+     * v3  electronics: enable = true (false) ignore (take) ttc commands from backplane for this AMC
+     * v2b electronics: enable = true (false) start (stop) the T1Controller for link ohN
+     */
+
     wisc::RPCSvc* rpc_loc = getRPCptr();
     req = wisc::RPCMsg("calibration_routines.ttcGenToggle");
     req.set_word("ohN", ohN);
-    req.set_word("bRun", bRun);
+    req.set_word("enable", enable);
     try {
         rsp = rpc_loc->call_method(req);
     }
@@ -19,11 +24,30 @@ DLLEXPORT uint32_t ttcGenToggle(uint32_t ohN, bool bRun){
 /***
  * @brief configure TTC generator
  */
-DLLEXPORT uint32_t ttcGenConf(uint32_t ohN, uint32_t mode, uint32_t type, uint32_t pulseDelay, uint32_t L1Ainterval, uint32_t nPulses, bool bRun)
+DLLEXPORT uint32_t ttcGenConf(uint32_t ohN, uint32_t mode, uint32_t type, uint32_t pulseDelay, uint32_t L1Ainterval, uint32_t nPulses, bool enable)
 {
+    /*
+     * v3  electronics Behavior:
+     *      pulseDelay (only for enable = true), delay between CalPulse and L1A
+     *      L1Ainterval (only for enable = true), how often to repeat signals
+     *      enable = true (false) ignore (take) ttc commands from backplane for this AMC (affects all links)
+     * v2b electronics behavior:
+     *      Configure the T1 controller
+     *      mode: 0 (Single T1 signal),
+     *            1 (CalPulse followed by L1A),
+     *            2 (pattern)
+     *      type (only for mode 0, type of T1 signal to send):
+     *            0 L1A
+     *            1 CalPulse
+     *            2 Resync
+     *            3 BC0
+     *      pulseDelay (only for mode 1), delay between CalPulse and L1A
+     *      L1Ainterval (only for mode 0,1), how often to repeat signals
+     *      nPulses how many signals to send (0 is continuous)
+     *      enable = true (false) start (stop) the T1Controller for link ohN
+     */
+
     wisc::RPCSvc* rpc_loc = getRPCptr();
-    //wisc::RPCMsg req_loc, rsp_loc;
-    //req_loc = wisc::RPCMsg("calibration_routines.ttcGenConf");
     req = wisc::RPCMsg("calibration_routines.ttcGenConf");
     req.set_word("ohN", ohN);
     req.set_word("mode", mode);
@@ -31,7 +55,7 @@ DLLEXPORT uint32_t ttcGenConf(uint32_t ohN, uint32_t mode, uint32_t type, uint32
     req.set_word("pulseDelay", pulseDelay);
     req.set_word("L1Ainterval", L1Ainterval);
     req.set_word("nPulses", nPulses);
-    req.set_word("bRun", bRun);
+    req.set_word("enable", enable);
     try {
         rsp = rpc_loc->call_method(req);
     }

--- a/src/common/rpc_manager/optohybrid.cc
+++ b/src/common/rpc_manager/optohybrid.cc
@@ -64,3 +64,116 @@ DLLEXPORT uint32_t broadcastWrite(uint32_t ohN, char * regName, uint32_t value, 
     }
     return 0;
 }
+
+
+DLLEXPORT uint32_t configureScanModule(uint32_t ohN, uint32_t vfatN, uint32_t scanmode, bool useUltra,
+        uint32_t vfatMask, uint32_t ch, uint32_t nevts, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep){
+    req = wisc::RPCMsg("optohybrid.configureScanModule");
+
+    req.set_word("ohN",ohN);
+    req.set_word("scanmode",scanmode);
+    if (useUltra){
+        req.set_word("useUltra",useUltra);
+        req.set_word("mask",vfatMask);
+    }
+    else{
+        req.set_word("vfatN",vfatN);
+    }
+    req.set_word("ch", ch); //channel
+    req.set_word("nevts",nevts);
+    req.set_word("dacMin",dacMin);
+    req.set_word("dacMax",dacMax);
+    req.set_word("dacStep",dacStep);
+
+    wisc::RPCSvc* rpc_loc = getRPCptr();
+
+    try {
+        rsp = rpc_loc->call_method(req);
+    }
+    STANDARD_CATCH;
+
+    if (rsp.get_key_exists("error")) {
+        printf("Caught an error: %s\n", (rsp.get_string("error")).c_str());
+        return 1;
+    }
+
+    return 0;
+} //End configureScanModule(...)
+
+DLLEXPORT uint32_t printScanConfiguration(uint32_t ohN, bool useUltra){
+    req = wisc::RPCMsg("optohybrid.printScanConfiguration");
+
+    req.set_word("ohN",ohN);
+    if (useUltra){
+        req.set_word("useUltra",useUltra);
+    }
+
+    wisc::RPCSvc* rpc_loc = getRPCptr();
+
+    try {
+        rsp = rpc_loc->call_method(req);
+    }
+    STANDARD_CATCH;
+
+    if (rsp.get_key_exists("error")) {
+        printf("Caught an error: %s\n", (rsp.get_string("error")).c_str());
+        return 1;
+    }
+
+    return 0;
+} //End printScanConfiguration(...)
+
+DLLEXPORT uint32_t startScanModule(uint32_t ohN, bool useUltra){
+    req = wisc::RPCMsg("optohybrid.startScanModule");
+
+    req.set_word("ohN",ohN);
+    if (useUltra){
+        req.set_word("useUltra",useUltra);
+    }
+
+    wisc::RPCSvc* rpc_loc = getRPCptr();
+
+    try {
+        rsp = rpc_loc->call_method(req);
+    }
+    STANDARD_CATCH;
+
+    if (rsp.get_key_exists("error")) {
+        printf("Caught an error: %s\n", (rsp.get_string("error")).c_str());
+        return 1;
+    }
+
+    return 0;
+} //End startScanModule(...)
+
+DLLEXPORT uint32_t getUltraScanResults(uint32_t ohN, uint32_t nevts, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep, uint32_t * result){
+    req = wisc::RPCMsg("optohybrid.getUltraScanResults");
+
+    req.set_word("ohN",ohN);
+    req.set_word("nevts",nevts);
+    req.set_word("dacMin",dacMin);
+    req.set_word("dacMax",dacMax);
+    req.set_word("dacStep",dacStep);
+
+    wisc::RPCSvc* rpc_loc = getRPCptr();
+
+    try {
+        rsp = rpc_loc->call_method(req);
+    }
+    STANDARD_CATCH;
+
+    if (rsp.get_key_exists("error")) {
+        printf("Caught an error: %s\n", (rsp.get_string("error")).c_str());
+        return 1;
+    }
+    const uint32_t size = (dacMax - dacMin+1)*24/dacStep;
+    if (rsp.get_key_exists("data")) {
+        ASSERT(rsp.get_word_array_size("data") == size);
+        rsp.get_word_array("data", result);
+    } else {
+        printf("No data key found");
+        return 1;
+    }
+
+    return 0;
+} //End getUltraScanResults(...)

--- a/src/common/rpc_manager/optohybrid.cc
+++ b/src/common/rpc_manager/optohybrid.cc
@@ -177,3 +177,26 @@ DLLEXPORT uint32_t getUltraScanResults(uint32_t ohN, uint32_t nevts, uint32_t da
 
     return 0;
 } //End getUltraScanResults(...)
+
+DLLEXPORT uint32_t stopCalPulse2AllChannels(uint32_t ohN, uint32_t mask, uint32_t ch_min, uint32_t ch_max){
+    req = wisc::RPCMsg("optohybrid.stopCalPulse2AllChannels");
+
+    req.set_word("ohN",ohN);
+    req.set_word("mask",mask);
+    req.set_word("ch_min",ch_min);
+    req.set_word("ch_max",ch_max);
+
+    wisc::RPCSvc* rpc_loc = getRPCptr();
+
+    try {
+        rsp = rpc_loc->call_method(req);
+    }
+    STANDARD_CATCH;
+
+    if (rsp.get_key_exists("error")) {
+        printf("Caught an error: %s\n", (rsp.get_string("error")).c_str());
+        return 1;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
I have expanded the scan tools for v3 electronics to also work with v2b electronics. The modules identify at runtime what behavior should be executed.

Requires: https://github.com/cms-gem-daq-project/ctp7_modules/pull/13

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
If we are moving toward RPC/XHAL framework for CTP7 we should have the tools for both v2b and v3 electronics rather than having to move back and forth between libraries.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
A complete working example is shown here:
http://cmsonline.cern.ch/cms-elog/1020178

For the v2b electronics I took a per channel threshold scan using the ipbus/uhal framework and then compared the results obtained when taking data with the rpc/xhal tools shown here. As can be seen the behavior is identical.

Additionally as shown the tools also work on v3 electronics.

### Screenshots (if appropriate):
See above elog post.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
