### PR TITLE
New Feature: SBIT Rate Scan vs. Arbitrary Scan Register

### DIFF
--- a/include/xhal/rpc/calibration_routines.h
+++ b/include/xhal/rpc/calibration_routines.h
@@ -8,7 +8,7 @@ DLLEXPORT uint32_t ttcGenConf(uint32_t ohN, uint32_t mode, uint32_t type, uint32
         uint32_t L1Ainterval, uint32_t nPulses, bool enable);
 DLLEXPORT uint32_t genScan(uint32_t nevts, uint32_t ohN, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep,
         uint32_t ch, bool useCalPulse, uint32_t mask, char * scanReg, bool useUltra, bool useExtTrig, uint32_t * result);
-DLLEXPORT uint32_t sbitRateScan(uint32_t ohN, uint32_t vfatN, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep, uint32_t ch, uint32_t maskOh,
+DLLEXPORT uint32_t sbitRateScan(uint32_t ohN, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep, uint32_t ch, uint32_t maskOh,
         char * scanReg, uint32_t waitTime, uint32_t * resultDacVal, uint32_t * resultTrigRate);
 
 #endif

--- a/include/xhal/rpc/calibration_routines.h
+++ b/include/xhal/rpc/calibration_routines.h
@@ -8,7 +8,7 @@ DLLEXPORT uint32_t ttcGenConf(uint32_t ohN, uint32_t mode, uint32_t type, uint32
         uint32_t L1Ainterval, uint32_t nPulses, bool enable);
 DLLEXPORT uint32_t genScan(uint32_t nevts, uint32_t ohN, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep,
         uint32_t ch, bool useCalPulse, uint32_t mask, char * scanReg, bool useUltra, bool useExtTrig, uint32_t * result);
-DLLEXPORT uint32_t sbitRateScan(uint32_t ohN, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep, uint32_t ch, uint32_t maskOh,
-        char * scanReg, uint32_t * resultDacVal, uint32_t * resultTrigRate);
+DLLEXPORT uint32_t sbitRateScan(uint32_t ohN, uint32_t vfatN, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep, uint32_t ch, uint32_t maskOh,
+        char * scanReg, uint32_t waitTime, uint32_t * resultDacVal, uint32_t * resultTrigRate);
 
 #endif

--- a/include/xhal/rpc/calibration_routines.h
+++ b/include/xhal/rpc/calibration_routines.h
@@ -8,5 +8,7 @@ DLLEXPORT uint32_t ttcGenConf(uint32_t ohN, uint32_t mode, uint32_t type, uint32
         uint32_t L1Ainterval, uint32_t nPulses, bool enable);
 DLLEXPORT uint32_t genScan(uint32_t nevts, uint32_t ohN, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep,
         uint32_t ch, bool useCalPulse, uint32_t mask, char * scanReg, bool useUltra, bool useExtTrig, uint32_t * result);
+DLLEXPORT uint32_t sbitRateScan(uint32_t ohN, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep, uint32_t ch, uint32_t maskOh,
+        char * scanReg, uint32_t * resultDacVal, uint32_t * resultTrigRate);
 
 #endif

--- a/include/xhal/rpc/calibration_routines.h
+++ b/include/xhal/rpc/calibration_routines.h
@@ -9,6 +9,6 @@ DLLEXPORT uint32_t ttcGenConf(uint32_t ohN, uint32_t mode, uint32_t type, uint32
 DLLEXPORT uint32_t genScan(uint32_t nevts, uint32_t ohN, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep,
         uint32_t ch, bool useCalPulse, uint32_t mask, char * scanReg, bool useUltra, bool useExtTrig, uint32_t * result);
 DLLEXPORT uint32_t sbitRateScan(uint32_t ohN, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep, uint32_t ch, uint32_t maskOh,
-        char * scanReg, uint32_t waitTime, uint32_t * resultDacVal, uint32_t * resultTrigRate);
+        bool invertVFATPos, char * scanReg, uint32_t waitTime, uint32_t * resultDacVal, uint32_t * resultTrigRate);
 
 #endif

--- a/src/common/rpc_manager/calibration_routines.cc
+++ b/src/common/rpc_manager/calibration_routines.cc
@@ -111,17 +111,19 @@ DLLEXPORT uint32_t genScan(uint32_t nevts, uint32_t ohN, uint32_t dacMin, uint32
     return 0;
 }
 
-DLLEXPORT uint32_t sbitRateScan(uint32_t ohN, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep, uint32_t ch, uint32_t maskOh, char * scanReg, uint32_t * resultDacVal, uint32_t * resultTrigRate){
+DLLEXPORT uint32_t sbitRateScan(uint32_t ohN, uint32_t vfatN, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep, uint32_t ch, uint32_t maskOh, char * scanReg, uint32_t waitTime, uint32_t * resultDacVal, uint32_t * resultTrigRate){
     req = wisc::RPCMsg("calibration_routines.sbitRateScan");
 
 
     req.set_word("ohN", ohN);
     req.set_word("maskOh", maskOh);
+    req.set_word("vfatN", vfatN);
     req.set_word("dacMin", dacMin);
     req.set_word("dacMax", dacMax);
     req.set_word("dacStep", dacStep);
     req.set_word("ch", ch);
     req.set_string("scanReg", std::string(scanReg));
+    req.set_word("waitTime", waitTime);
 
     wisc::RPCSvc* rpc_loc = getRPCptr();
 

--- a/src/common/rpc_manager/calibration_routines.cc
+++ b/src/common/rpc_manager/calibration_routines.cc
@@ -111,12 +111,13 @@ DLLEXPORT uint32_t genScan(uint32_t nevts, uint32_t ohN, uint32_t dacMin, uint32
     return 0;
 }
 
-DLLEXPORT uint32_t sbitRateScan(uint32_t ohN, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep, uint32_t ch, uint32_t maskOh, char * scanReg, uint32_t waitTime, uint32_t * resultDacVal, uint32_t * resultTrigRate){
+DLLEXPORT uint32_t sbitRateScan(uint32_t ohN, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep, uint32_t ch, uint32_t maskOh, bool invertVFATPos, char * scanReg, uint32_t waitTime, uint32_t * resultDacVal, uint32_t * resultTrigRate){
     req = wisc::RPCMsg("calibration_routines.sbitRateScan");
 
 
     req.set_word("ohN", ohN);
     req.set_word("maskOh", maskOh);
+    req.set_word("invertVFATPos", invertVFATPos);
     req.set_word("dacMin", dacMin);
     req.set_word("dacMax", dacMax);
     req.set_word("dacStep", dacStep);

--- a/src/common/rpc_manager/calibration_routines.cc
+++ b/src/common/rpc_manager/calibration_routines.cc
@@ -110,3 +110,46 @@ DLLEXPORT uint32_t genScan(uint32_t nevts, uint32_t ohN, uint32_t dacMin, uint32
 
     return 0;
 }
+
+DLLEXPORT uint32_t sbitRateScan(uint32_t ohN, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep, uint32_t ch, uint32_t maskOh, char * scanReg, uint32_t * resultDacVal, uint32_t * resultTrigRate){
+    req = wisc::RPCMsg("calibration_routines.sbitRateScan");
+
+
+    req.set_word("ohN", ohN);
+    req.set_word("maskOh", maskOh);
+    req.set_word("dacMin", dacMin);
+    req.set_word("dacMax", dacMax);
+    req.set_word("dacStep", dacStep);
+    req.set_word("ch", ch);
+    req.set_string("scanReg", std::string(scanReg));
+
+    wisc::RPCSvc* rpc_loc = getRPCptr();
+
+    try {
+        rsp = rpc_loc->call_method(req);
+    }
+    STANDARD_CATCH;
+
+    if (rsp.get_key_exists("error")) {
+        printf("Caught an error: %s\n", (rsp.get_string("error")).c_str());
+        return 1;
+    }
+    const uint32_t size = (dacMax - dacMin+1)/dacStep;
+    if (rsp.get_key_exists("data_dacVal")) {
+        ASSERT(rsp.get_word_array_size("data_dacVal") == size);
+        rsp.get_word_array("data_dacVal", resultDacVal);
+    } else {
+        printf("No key found for data dac values");
+        return 1;
+    }
+
+    if (rsp.get_key_exists("data_trigRate")) {
+        ASSERT(rsp.get_word_array_size("data_trigRate") == size);
+        rsp.get_word_array("data_trigRate", resultTrigRate);
+    } else {
+        printf("No key found for data trigger rate values");
+        return 1;
+    }
+
+    return 0;
+} //End sbitRateScan(...)

--- a/src/common/rpc_manager/calibration_routines.cc
+++ b/src/common/rpc_manager/calibration_routines.cc
@@ -111,13 +111,12 @@ DLLEXPORT uint32_t genScan(uint32_t nevts, uint32_t ohN, uint32_t dacMin, uint32
     return 0;
 }
 
-DLLEXPORT uint32_t sbitRateScan(uint32_t ohN, uint32_t vfatN, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep, uint32_t ch, uint32_t maskOh, char * scanReg, uint32_t waitTime, uint32_t * resultDacVal, uint32_t * resultTrigRate){
+DLLEXPORT uint32_t sbitRateScan(uint32_t ohN, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep, uint32_t ch, uint32_t maskOh, char * scanReg, uint32_t waitTime, uint32_t * resultDacVal, uint32_t * resultTrigRate){
     req = wisc::RPCMsg("calibration_routines.sbitRateScan");
 
 
     req.set_word("ohN", ohN);
     req.set_word("maskOh", maskOh);
-    req.set_word("vfatN", vfatN);
     req.set_word("dacMin", dacMin);
     req.set_word("dacMax", dacMax);
     req.set_word("dacStep", dacStep);
@@ -126,6 +125,13 @@ DLLEXPORT uint32_t sbitRateScan(uint32_t ohN, uint32_t vfatN, uint32_t dacMin, u
     req.set_word("waitTime", waitTime);
 
     wisc::RPCSvc* rpc_loc = getRPCptr();
+
+    //Check to make sure (dacMax-dacMin+1)/dacStep is an integer!
+    if( 0 != ((dacMax - dacMin + 1) % dacStep) ){
+        printf("Caught an error: (dacMax - dacMin + 1)/dacStep must be an integer!\n");
+        return 1;
+    }
+    const uint32_t size = (dacMax - dacMin+1)/dacStep;
 
     try {
         rsp = rpc_loc->call_method(req);
@@ -136,7 +142,7 @@ DLLEXPORT uint32_t sbitRateScan(uint32_t ohN, uint32_t vfatN, uint32_t dacMin, u
         printf("Caught an error: %s\n", (rsp.get_string("error")).c_str());
         return 1;
     }
-    const uint32_t size = (dacMax - dacMin+1)/dacStep;
+
     if (rsp.get_key_exists("data_dacVal")) {
         ASSERT(rsp.get_word_array_size("data_dacVal") == size);
         rsp.get_word_array("data_dacVal", resultDacVal);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Provide functionality to use the sbit rate scan `ctp7_modules` from the host PC.  Requires: https://github.com/cms-gem-daq-project/ctp7_modules/pull/15

Please see the above PR link for full details.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
Perform an SBIT rate scan versus an arbitrary scan register from a host PC rather than being forced to execute it on the CTP7.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran some scans, see above PR link in `ctp7_modules` for full details. 

### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
