### PR TITLE
Modifying the parsers to handle xi:include

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ TARGET_TEST=${XHAL_ROOT}/test/bin/test
 RPC_SA_LIB=${XHAL_ROOT}/lib/x86_64/librwreg.so
 RPC_MAN_LIB=${XHAL_ROOT}/lib/x86_64/librpcman.so
 
-all:${TARGET_LIB} ${RPC_SA_LIB}
+all:${TARGET_LIB} ${RPC_SA_LIB} 
 
 rpc:${RPC_MAN_LIB}
 

--- a/etc/optohybrid_registers.xml
+++ b/etc/optohybrid_registers.xml
@@ -1,0 +1,1 @@
+optohybrid_registers_v3.xml

--- a/python/reg_interface/reg_interface.py
+++ b/python/reg_interface/reg_interface.py
@@ -504,7 +504,7 @@ if __name__ == '__main__':
             prompt.prompt = 'CTP7 > '
             print 'Starting CTP7 Register Command Line Interface. Please connect to CTP7 using connect <hostname> command unless you use it directly at the CTP7'
             prompt.cmdloop_with_keyboard_interrupt()
-        except TypeError:
-            print '[TypeError] Incorrect usage. See help'
+        except TypeError as te:
+            print '[TypeError] Incorrect usage. See help... ', te
         except KeyboardInterrupt:
             print '\n'

--- a/python/reg_interface/rw_reg.py
+++ b/python/reg_interface/rw_reg.py
@@ -1,4 +1,4 @@
-import xml.etree.ElementTree as xml
+import lxml.etree as xml
 import sys, os, subprocess, socket
 from time import sleep
 #import uhal
@@ -124,7 +124,8 @@ def main():
 def parseXML():
     print 'Parsing',ADDRESS_TABLE_TOP,'...'
     tree = xml.parse(ADDRESS_TABLE_TOP)
-    root = tree.getroot()[0]
+    tree.xinclude()
+    root = tree.getroot()
     vars = {}
     makeTree(root,'',0x0,nodes,None,vars,False)
 
@@ -141,7 +142,8 @@ def makeTree(node,baseName,baseAddress,nodes,parentNode,vars,isGenerated):
     newNode = Node()
     name = baseName
     if baseName != '': name += '.'
-    name += node.get('id')
+    if node.get('id') is not None and node.get("id") != "top":
+        name += node.get('id')
     name = substituteVars(name, vars)
     newNode.name = name
     if node.get('description') is not None:

--- a/setup.sh
+++ b/setup.sh
@@ -4,7 +4,7 @@ then
     export XHAL_ROOT=$(dirname $(readlink -f "$0") )
 else
     # bash specific, must be sourced from a bash shell...                                                                                                                                                                                                                         
-    export XHAL_ROOT=$(dirname "${BASH_SOURCE[0]}")
+    export XHAL_ROOT=$(dirname $(readlink -f "${BASH_SOURCE[0]}"))
 fi
 
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$XHAL_ROOT/lib

--- a/setup.sh
+++ b/setup.sh
@@ -1,3 +1,11 @@
-export XHAL_ROOT=$PWD
+if [[ ! "$0" =~ ("bash") ]]
+then
+    # best for calling from zsh                                                                                                                                                                                                                                                   
+    export XHAL_ROOT=$(dirname $(readlink -f "$0") )
+else
+    # bash specific, must be sourced from a bash shell...                                                                                                                                                                                                                         
+    export XHAL_ROOT=$(dirname "${BASH_SOURCE[0]}")
+fi
+
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$XHAL_ROOT/lib
-echo $XHAL_ROOT
+export PATH=$PATH:$XHAL_ROOT/python/reg_interface

--- a/test/units/parse_t.cpp
+++ b/test/units/parse_t.cpp
@@ -19,7 +19,7 @@ namespace xhal {
         {
           try 
           {
-            m_parser->setLogLevel(2);
+            m_parser->setLogLevel(3);
             m_parser->parseXML();
           } catch (...){
             std::cout << "Parsing failed" << std::endl;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Both python and C++ XML parsers are updated to handle the xi:include to link optohybrid_registers.xml address table. Python parser changed to lxml, C++ is changed to DOMLSParser.
Now in order to include the optohybrid nodes into the gem_amc_top.xml one need to:

- modify the `<node id="top">` node to be like: 
`<node id="top" xmlns:xi="http://www.w3.org/2001/XInclude">`

-  insert a following line in the `OH${OH_IDX}` node just before the `GEB` node:
`<xi:include href="optohybrid_registers.xml"/>`

The resulting part of xml should look like this:
```
     <node id="OH${OH_IDX}"  address="0x0"
            description="Optohybrid ${OH_IDX}"
            generate="true" generate_size="2" generate_address_step="0x00010000" generate_idx_var="OH_IDX">

        <!--Insert here the OH FPGA module -->
        <xi:include href="optohybrid_registers.xml"/>

        <node id="GEB"  address="0x100000"
              description="VFAT3 registers">
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
Fixes https://github.com/cms-gem-daq-project/xhal/issues/34

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested with `reg_interface` and C++ unit tests
### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
