### PR TITLE
New Feature: genScanLocal uses current pulse mode of calibration module #20

### DIFF
--- a/include/xhal/rpc/calibration_routines.h
+++ b/include/xhal/rpc/calibration_routines.h
@@ -7,7 +7,8 @@ DLLEXPORT uint32_t ttcGenToggle(uint32_t ohN, bool enable);
 DLLEXPORT uint32_t ttcGenConf(uint32_t ohN, uint32_t mode, uint32_t type, uint32_t pulseDelay,
         uint32_t L1Ainterval, uint32_t nPulses, bool enable);
 DLLEXPORT uint32_t genScan(uint32_t nevts, uint32_t ohN, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep,
-        uint32_t ch, bool useCalPulse, uint32_t mask, char * scanReg, bool useUltra, bool useExtTrig, uint32_t * result);
+        uint32_t ch, bool useCalPulse, bool currentPulse, uint32_t mask, char * scanReg, bool useUltra, bool useExtTrig,
+        uint32_t * result);
 DLLEXPORT uint32_t sbitRateScan(uint32_t ohN, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep, uint32_t ch, uint32_t maskOh,
         bool invertVFATPos, char * scanReg, uint32_t waitTime, uint32_t * resultDacVal, uint32_t * resultTrigRate);
 

--- a/include/xhal/rpc/calibration_routines.h
+++ b/include/xhal/rpc/calibration_routines.h
@@ -7,7 +7,7 @@ DLLEXPORT uint32_t ttcGenToggle(uint32_t ohN, bool enable);
 DLLEXPORT uint32_t ttcGenConf(uint32_t ohN, uint32_t mode, uint32_t type, uint32_t pulseDelay,
         uint32_t L1Ainterval, uint32_t nPulses, bool enable);
 DLLEXPORT uint32_t genScan(uint32_t nevts, uint32_t ohN, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep,
-        uint32_t ch, bool useCalPulse, bool currentPulse, uint32_t mask, char * scanReg, bool useUltra, bool useExtTrig,
+        uint32_t ch, bool useCalPulse, bool currentPulse, uint32_t calScaleFactor, uint32_t mask, char * scanReg, bool useUltra, bool useExtTrig,
         uint32_t * result);
 DLLEXPORT uint32_t sbitRateScan(uint32_t ohN, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep, uint32_t ch, uint32_t maskOh,
         bool invertVFATPos, char * scanReg, uint32_t waitTime, uint32_t * resultDacVal, uint32_t * resultTrigRate);

--- a/src/common/rpc_manager/calibration_routines.cc
+++ b/src/common/rpc_manager/calibration_routines.cc
@@ -70,7 +70,7 @@ DLLEXPORT uint32_t ttcGenConf(uint32_t ohN, uint32_t mode, uint32_t type, uint32
 /***
  * @brief run a generic scan routine
  */
-DLLEXPORT uint32_t genScan(uint32_t nevts, uint32_t ohN, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep, uint32_t ch, bool useCalPulse, bool currentPulse, uint32_t mask, char * scanReg, bool useUltra, bool useExtTrig, uint32_t * result)
+DLLEXPORT uint32_t genScan(uint32_t nevts, uint32_t ohN, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep, uint32_t ch, bool useCalPulse, bool currentPulse, uint32_t calScaleFactor, uint32_t mask, char * scanReg, bool useUltra, bool useExtTrig, uint32_t * result)
 {
     req = wisc::RPCMsg("calibration_routines.genScan");
 
@@ -82,6 +82,7 @@ DLLEXPORT uint32_t genScan(uint32_t nevts, uint32_t ohN, uint32_t dacMin, uint32
     req.set_word("ch", ch);
     req.set_word("useCalPulse", useCalPulse);
     req.set_word("currentPulse", currentPulse);
+    req.set_word("calScaleFactor", calScaleFactor);
     req.set_word("mask", mask);
     if(useUltra){
         req.set_word("useUltra", useUltra);

--- a/src/common/rpc_manager/calibration_routines.cc
+++ b/src/common/rpc_manager/calibration_routines.cc
@@ -70,7 +70,7 @@ DLLEXPORT uint32_t ttcGenConf(uint32_t ohN, uint32_t mode, uint32_t type, uint32
 /***
  * @brief run a generic scan routine
  */
-DLLEXPORT uint32_t genScan(uint32_t nevts, uint32_t ohN, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep, uint32_t ch, bool useCalPulse, uint32_t mask, char * scanReg, bool useUltra, bool useExtTrig, uint32_t * result)
+DLLEXPORT uint32_t genScan(uint32_t nevts, uint32_t ohN, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep, uint32_t ch, bool useCalPulse, bool currentPulse, uint32_t mask, char * scanReg, bool useUltra, bool useExtTrig, uint32_t * result)
 {
     req = wisc::RPCMsg("calibration_routines.genScan");
 
@@ -81,6 +81,7 @@ DLLEXPORT uint32_t genScan(uint32_t nevts, uint32_t ohN, uint32_t dacMin, uint32
     req.set_word("dacStep", dacStep);
     req.set_word("ch", ch);
     req.set_word("useCalPulse", useCalPulse);
+    req.set_word("currentPulse", currentPulse);
     req.set_word("mask", mask);
     if(useUltra){
         req.set_word("useUltra", useUltra);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
See https://github.com/cms-gem-daq-project/ctp7_modules/pull/20 for full details.

Provides functionality for using current pulse injection mode. 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
Full description given in associated `ctp7_modules` PR.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
See http://cmsonline.cern.ch/cms-elog/1028540

### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
