### PR TITLE
Adding update_lmdb method to reg_interface

### DIFF
--- a/python/reg_interface/reg_interface.py
+++ b/python/reg_interface/reg_interface.py
@@ -470,6 +470,14 @@ class Prompt(Cmd):
             print 'Incorrect usage.'
             return
 
+    def do_update_lmdb(self, args):
+        """Updates LMDB address table at the CTP7. USAGE: update_lmdb <absolute path name to the AMC xml address table at the CTP7>"""
+        if 'eagle' in hostname:
+            print 'This function can only be run from a host PC'
+        else:
+            update_atdb(args)
+            print 'LMDB address table updated'
+
     def execute(self, other_function, args):
         other_function = 'do_'+other_function
         call_func = getattr(Prompt,other_function)

--- a/python/reg_interface/rw_reg.py
+++ b/python/reg_interface/rw_reg.py
@@ -54,6 +54,10 @@ else:
   rList.restype = c_uint
   rList.argtypes=[POINTER(c_uint32),POINTER(c_uint32)]
 
+  update_atdb = lib.update_atdb
+  update_atdb.argtypes = [c_char_p]
+  update_atdb.restype = c_uint
+
   ADDRESS_TABLE_TOP = os.getenv("XHAL_ROOT")+'/etc/gem_amc_top.xml'
 
 
@@ -107,7 +111,7 @@ def main():
     print len(kids), kids.name
 
 def parseXML():
-    print 'Open pickled address table if available ',ADDRESS_TABLE_TOP[:-3],'pickle...'
+    print 'Open pickled address table if available ',ADDRESS_TABLE_TOP[:-3]+'pickle...'
 
     fname =  ADDRESS_TABLE_TOP[:-3] + "pickle"
     try:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Every time the XML address table receives update, the LMDB address table should be updated as well. Given PR adds a methos `update_lmdb` to the `reg_interface.py`

Usage:
after connecting to a given CTP7 card from the host PC, run:
```
update_lmdb /full/path/on/CTP7/to/new/address_table.xml
```
### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested at `gem904qc8daq`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->