### PR TITLE
Improve the version detection when making a release

### DIFF
--- a/python/reg_interface_gem/MANIFEST.in
+++ b/python/reg_interface_gem/MANIFEST.in
@@ -3,4 +3,5 @@ include README.md
 include MANIFEST.in
 include LICENSE
 include requirements.txt
+include xhal/_version.py
 recursive-include xhal/scripts *

--- a/python/reg_interface_gem/Makefile
+++ b/python/reg_interface_gem/Makefile
@@ -61,7 +61,10 @@ clean:
 	-rm -f  pkg/CHANGELOG.md
 	-rm -f  pkg/requirements.txt
 
-rpm: _rpmall _rpmarm 
+rpm: _rpmall _rpmarm _harvest
+	@echo "Running xhal reg_interface_gem rpm target"
+	find $(RPMBUILD_DIR)/dist -iname "*.rpm" -print0 -exec mv -t $(RPMBUILD_DIR) {} \+
+	find $(RPMBUILD_DIR)/arm -iname "*.rpm" -print0 -exec mv -t $(RPMBUILD_DIR) {} \+
 
 print-env:
 	@echo BUILD_HOME     $(BUILD_HOME)

--- a/python/reg_interface_gem/pkg/setup.py
+++ b/python/reg_interface_gem/pkg/setup.py
@@ -21,10 +21,6 @@ def getreqs():
 def getVersion():
     __version__='___version___'
     __release__='___release___'
-    if __release__.split('.')[2]:
-        __prerel__='-{0:s}'.format(__release__.split('.')[2])
-    else:
-        __prerel__=''
     __buildtag__='___buildtag___'
     __gitrev__='___gitrev___'
     __gitver__='___gitver___'
@@ -32,7 +28,7 @@ def getVersion():
     __builddate__='___builddate___'
     with open("xhal/_version.py","w") as verfile:
         verfile.write("""
-## This file is generated automatically from xhal_reg_interface_gem setup.py
+## This file is generated automatically from cmsgemos_gempython setup.py
 __version__='{0:s}'
 __release__='{1:s}'
 __buildtag__='{2:s}'
@@ -41,7 +37,6 @@ __gitver__='{4:s}'
 __packager__='{5:s}'
 __builddate__='{6:s}'
 """.format(__version__,__release__,__buildtag__,__gitrev__,__gitver__,__packager__,__builddate__))
-    # return '{0:s}{1:s}'.format(__version__,__prerel__)
     return '{0:s}'.format(__version__)
 
 setup(name             = '__packagename__',

--- a/python/reg_interface_gem/pkg/setup.py
+++ b/python/reg_interface_gem/pkg/setup.py
@@ -28,7 +28,7 @@ def getVersion():
     __builddate__='___builddate___'
     with open("xhal/_version.py","w") as verfile:
         verfile.write("""
-## This file is generated automatically from cmsgemos_gempython setup.py
+## This file is generated automatically from reg_interface_gem setup.py
 __version__='{0:s}'
 __release__='{1:s}'
 __buildtag__='{2:s}'


### PR DESCRIPTION
## Description
Updates the `gembuild` pointer to the latest version for extraction of build information based on the closest tag

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Enhancement (non-breaking change which adds functionality)

## Motivation and Context
Allows the releases to always be sequential in their machine understood versioning, such that a new RPM can be installed in the case that the version number hasn't changed (testing releases)

## How Has This Been Tested?
Installed at P5 on top of current RPMs