### PR TITLE
pick up version number from tag

### DIFF
--- a/python/reg_interface_gem/Makefile
+++ b/python/reg_interface_gem/Makefile
@@ -20,9 +20,9 @@ ScriptDir    := pkg/$(Namespace)/scripts
 PythonModules = ["$(Namespace).$(ShortPackage)"]
 $(info PythonModules=${PythonModules})
 
-REG_INTERFACE_GEM_VER_MAJOR=1
-REG_INTERFACE_GEM_VER_MINOR=0
-REG_INTERFACE_GEM_VER_PATCH=0
+REG_INTERFACE_GEM_VER_MAJOR:=$(shell $(BUILD_HOME)/$(Project)/config/tag2rel.sh | awk '{split($$0,a," "); print a[1];}' | awk '{split($$0,b,":"); print b[2];}')
+REG_INTERFACE_GEM_VER_MINOR:=$(shell $(BUILD_HOME)/$(Project)/config/tag2rel.sh | awk '{split($$0,a," "); print a[2];}' | awk '{split($$0,b,":"); print b[2];}')
+REG_INTERFACE_GEM_VER_PATCH:=$(shell $(BUILD_HOME)/$(Project)/config/tag2rel.sh | awk '{split($$0,a," "); print a[3];}' | awk '{split($$0,b,":"); print b[2];}')
 
 include $(BUILD_HOME)/$(Project)/config/mfCommonDefs.mk
 include $(BUILD_HOME)/$(Project)/config/mfPythonDefs.mk

--- a/xhalarm/Makefile
+++ b/xhalarm/Makefile
@@ -9,9 +9,9 @@ PackageDir   := pkg/$(ShortPackage)
 Packager     := Mykhailo Dalchenko
 Arch         := arm
 
-XHAL_VER_MAJOR=1
-XHAL_VER_MINOR=0
-XHAL_VER_PATCH=0
+XHAL_VER_MAJOR:=$(shell $(BUILD_HOME)/$(Project)/config/tag2rel.sh | awk '{split($$0,a," "); print a[1];}' | awk '{split($$0,b,":"); print b[2];}')
+XHAL_VER_MINOR:=$(shell $(BUILD_HOME)/$(Project)/config/tag2rel.sh | awk '{split($$0,a," "); print a[2];}' | awk '{split($$0,b,":"); print b[2];}')
+XHAL_VER_PATCH:=$(shell $(BUILD_HOME)/$(Project)/config/tag2rel.sh | awk '{split($$0,a," "); print a[3];}' | awk '{split($$0,b,":"); print b[2];}')
 
 include $(BUILD_HOME)/$(Project)/config/mfZynq.mk
 include $(BUILD_HOME)/$(Project)/config/mfCommonDefs.mk

--- a/xhalarm/Makefile
+++ b/xhalarm/Makefile
@@ -13,8 +13,8 @@ XHAL_VER_MAJOR:=$(shell $(BUILD_HOME)/$(Project)/config/tag2rel.sh | awk '{split
 XHAL_VER_MINOR:=$(shell $(BUILD_HOME)/$(Project)/config/tag2rel.sh | awk '{split($$0,a," "); print a[2];}' | awk '{split($$0,b,":"); print b[2];}')
 XHAL_VER_PATCH:=$(shell $(BUILD_HOME)/$(Project)/config/tag2rel.sh | awk '{split($$0,a," "); print a[3];}' | awk '{split($$0,b,":"); print b[2];}')
 
-include $(BUILD_HOME)/$(Project)/config/mfZynq.mk
 include $(BUILD_HOME)/$(Project)/config/mfCommonDefs.mk
+include $(BUILD_HOME)/$(Project)/config/mfZynq.mk
 include $(BUILD_HOME)/$(Project)/config/mfRPMRules.mk
 
 ADDFLAGS=-std=gnu++14

--- a/xhalcore/Makefile
+++ b/xhalcore/Makefile
@@ -16,7 +16,6 @@ XHAL_VER_PATCH:=$(shell $(BUILD_HOME)/$(Project)/config/tag2rel.sh | awk '{split
 include $(BUILD_HOME)/$(Project)/config/mfCommonDefs.mk
 include $(BUILD_HOME)/$(Project)/config/mfRPMRules.mk
 
-CC=g++
 CCFLAGS=-O0 -g3 -fno-inline -Wall -fPIC -pthread -m64
 ADDFLAGS=-std=gnu++14
 

--- a/xhalcore/Makefile
+++ b/xhalcore/Makefile
@@ -9,9 +9,9 @@ PackageDir   := pkg/$(ShortPackage)
 Packager     := Mykhailo Dalchenko
 Arch         := x86_64
 
-XHAL_VER_MAJOR=1
-XHAL_VER_MINOR=0
-XHAL_VER_PATCH=0
+XHAL_VER_MAJOR:=$(shell $(BUILD_HOME)/$(Project)/config/tag2rel.sh | awk '{split($$0,a," "); print a[1];}' | awk '{split($$0,b,":"); print b[2];}')
+XHAL_VER_MINOR:=$(shell $(BUILD_HOME)/$(Project)/config/tag2rel.sh | awk '{split($$0,a," "); print a[2];}' | awk '{split($$0,b,":"); print b[2];}')
+XHAL_VER_PATCH:=$(shell $(BUILD_HOME)/$(Project)/config/tag2rel.sh | awk '{split($$0,a," "); print a[3];}' | awk '{split($$0,b,":"); print b[2];}')
 
 include $(BUILD_HOME)/$(Project)/config/mfCommonDefs.mk
 include $(BUILD_HOME)/$(Project)/config/mfRPMRules.mk


### PR DESCRIPTION
## Motivation and Context
Makes sure versions come from the tag and number of commits since last tag.
Allows uniformly sequential builds to be built.

## How Has This Been Tested?
Tested `make rpm` with a final, preliminary, and untagged commit
