### PR TITLE
New Feature: adding xhal method for getting vfat3 channel register settings

### DIFF
--- a/xhalcore/include/xhal/rpc/vfat3.h
+++ b/xhalcore/include/xhal/rpc/vfat3.h
@@ -5,6 +5,14 @@
 
 DLLEXPORT uint32_t configureVFAT3s(uint32_t ohN, uint32_t vfatMask);
 
+/*! \gn DLLEXPORT uint32_t configureVFAT3s(uint32_t ohN, uint32_t vfatMask)
+ *  \brief reads channel registers of all unmasked vfats on ohN
+ *  \param ohN Optohybrid optical link number
+ *  \param vfatMask Bitmask of chip positions determining which chips to use
+ *  \param chanRegData array pointer for channel register data with 3072 entries, the (vfat,chan) pairing determines the array index via: idx = vfat*128 + chan
+ */
+DLLEXPORT uint32_t getChannelRegistersVFAT3(uint32_t ohN, uint32_t vfatMask, uint32_t *chanRegData);
+
 /*! \fn DLLEXPORT uint32_t setChannelRegistersVFAT3(uint32_t ohN, uint32_t vfatMask, uint32_t *calEnable, uint32_t *masks, uint32_t *trimARM, uint32_t *trimARMPol, uint32_t *trimZCC, uint32_t *trimZCCPol)
  *  \brief sets all vfat3 channel registers
  *  \param ohN Optohybrid optical link number

--- a/xhalcore/src/common/rpc_manager/vfat3.cc
+++ b/xhalcore/src/common/rpc_manager/vfat3.cc
@@ -24,6 +24,36 @@ DLLEXPORT uint32_t configureVFAT3s(uint32_t ohN, uint32_t vfatMask)
     return 0;
 }
 
+DLLEXPORT uint32_t getChannelRegistersVFAT3(uint32_t ohN, uint32_t vfatMask, uint32_t *chanRegData){
+    req = wisc::RPCMsg("vfat3.getChannelRegistersVFAT3");
+
+    req.set_word("ohN",ohN);
+    req.set_word("vfatMask",vfatMask);
+
+    wisc::RPCSvc* rpc_loc = getRPCptr();
+
+    try {
+        rsp = rpc_loc->call_method(req);
+    }
+    STANDARD_CATCH;
+
+    if (rsp.get_key_exists("error")) {
+        printf("Caught an error: %s\n", (rsp.get_string("error")).c_str());
+        return 1;
+    }
+
+    const uint32_t size = 3072;
+    if (rsp.get_key_exists("chanRegData")) {
+        ASSERT(rsp.get_word_array_size("chanRegData") == size);
+        rsp.get_word_array("chanRegData", chanRegData);
+    } else {
+        printf("No channel register data found");
+        return 1;
+    }
+
+    return 0;
+}
+
 DLLEXPORT uint32_t setChannelRegistersVFAT3(uint32_t ohN, uint32_t vfatMask, uint32_t *calEnable, uint32_t *masks, uint32_t *trimARM, uint32_t *trimARMPol, uint32_t *trimZCC, uint32_t *trimZCCPol){
     req = wisc::RPCMsg("vfat3.setChannelRegistersVFAT3");
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Implemented xhal methods for fast read of vfat3 channel registers.

Returns an array of 3072 in size which contains the 16 bit channel register for each channel.  The array index goes as `idx = 128 * vfat + chan`.  Masked vfats will still be included in the output array but the value returned for the channel register will be `0x0`.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
There was no rpc method for reading back channel registers requiring a large number atomic transactions to query this information.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested in [this elog post](http://cmsonline.cern.ch/cms-elog/1055032)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
