### PR TITLE
New Feature: expose bindings to python with boost::python

### DIFF
--- a/xhalcore/Makefile
+++ b/xhalcore/Makefile
@@ -87,7 +87,8 @@ $(OBJS_RPC_MAN):$(SRCS_RPC_MAN)
 	$(CC) $(CCFLAGS) $(ADDFLAGS) $(INC) $(LIB) -c $(@:%.o=%.cpp) -o $@ 
 
 $(XHALPY_LIB):$(OBJS_XHALPY)
-	$(CC) $(CCFLAGS) ${LDFLAGS} $(ADDFLAGS) $(INC) $(LIB) -lboost_python -L$(PYTHON_LIB_PREFIX) -l$(PYTHON_LIB) -Llib/ -lxhal -lrpcman -o $@ $<
+	#$(CC) $(CCFLAGS) ${LDFLAGS} $(ADDFLAGS) $(INC) $(LIB) -lboost_python -L$(PYTHON_LIB_PREFIX) -l$(PYTHON_LIB) -Llib/ -lxhal -lrpcman -o $@ $<
+	g++ $(CCFLAGS) ${LDFLAGS} $(ADDFLAGS) $(INC) $(LIB) -lboost_python -L$(PYTHON_LIB_PREFIX) -l$(PYTHON_LIB) -Llib/ -lxhal -lrpcman -o $@ $<
 
 $(OBJS_XHALPY):$(SRCS_XHALPY)
 	$(CC) $(CCFLAGS) $(ADDFLAGS) $(INC) -I$(PYTHON_INCLUDE_PREFIX) $(LIB) -c -o $@ $<

--- a/xhalcore/include/xhal/XHALDevice.h
+++ b/xhalcore/include/xhal/XHALDevice.h
@@ -3,7 +3,8 @@
  * Hardware device for XHAL
  *
  * @author Mykhailo Dalchenko
- * @version 1.0 
+ * @author Brian Dorney
+ * @version 1.0
  */
 
 #ifndef XHALDEVICE_H

--- a/xhalcore/include/xhal/XHALInterface.h
+++ b/xhalcore/include/xhal/XHALInterface.h
@@ -3,13 +3,15 @@
  * Hardware interface for XHAL
  *
  * @author Mykhailo Dalchenko
- * @version 1.0 
+ * @author Brian Dorney
+ * @version 1.0
  */
 
 #ifndef XHALINTERFACE_H
 #define XHALINTERFACE_H
 
 #include <cstring>
+#include <map>
 #include <string>
 #include "xhal/rpc/wiscrpcsvc.h"
 #include "xhal/utils/Exception.h"
@@ -43,7 +45,7 @@
   catch (wisc::RPCMsg::BadKeyException &e) { \
     ERROR("Caught exception: " << e.key.c_str()); \
     throw xhal::utils::XHALRPCException("RPC BadKeyException (most probably remote register not accessible): " + e.key);\
-	} 
+	}
 
 #define ASSERT(x) do { \
 		if (!(x)) { \
@@ -55,7 +57,7 @@
 namespace xhal {
   /**
    * @class XHALInterface
-   * @brief Provides interface to call remote procedures at Zynq CPU 
+   * @brief Provides interface to call remote procedures at Zynq CPU
    */
   class XHALInterface
   {
@@ -88,6 +90,11 @@ namespace xhal {
       void loadModule(const std::string& module_name, const std::string& module_version);
 
       /**
+       * @brief loads all modules stored in this->m_map_modName_modVer
+       */
+      void loadStoredModules();
+
+      /**
        * @brief sets amount of logging/debugging information to display
        * @param loglevel:
        * 0 - ERROR
@@ -100,6 +107,7 @@ namespace xhal {
 
     protected:
       std::string m_board_domain_name;
+      std::map<std::string,std::string> m_map_modName_modVer; //key->module_name; value->module_version
       log4cplus::Logger m_logger;
       wisc::RPCSvc rpc;
       wisc::RPCMsg req, rsp;

--- a/xhalcore/include/xhal/XHALInterface.h
+++ b/xhalcore/include/xhal/XHALInterface.h
@@ -74,6 +74,8 @@ namespace xhal {
        */
       void connect();
 
+      std::string getBoardName(){return m_board_domain_name;}
+
       /**
        * @brief Reconnect to RPC service and reload required modules
        */

--- a/xhalcore/include/xhal/rpc/amc.h
+++ b/xhalcore/include/xhal/rpc/amc.h
@@ -7,6 +7,7 @@
  *  \brief SBIT readout from optohybrid ohN for a number of seconds given by acquireTime; data is written to a file directory specified by outFilePath
  *  \param ohN Optohybrid optical link number
  *  \param acquireTime acquisition time on the wall clock in seconds
+ *  \return An integer from the set {0, 1, EIO}; where 0 indicates successful completion, 1 indicates an RPC error, and EIO is a platform dependent error code representing a file IO error
  */
 DLLEXPORT uint32_t sbitReadOut(uint32_t ohN, uint32_t acquireTime, char * outFilePath);
 

--- a/xhalcore/include/xhal/rpc/amc.h
+++ b/xhalcore/include/xhal/rpc/amc.h
@@ -1,3 +1,11 @@
+/**
+ * @file AMC.h
+ * Hardware device for uTCA AMC
+ *
+ * @author Brian Dorney
+ * @version 1.0
+ */
+
 #ifndef AMC_H
 #define AMC_H
 

--- a/xhalcore/include/xhal/rpc/amc.h
+++ b/xhalcore/include/xhal/rpc/amc.h
@@ -1,6 +1,8 @@
 #ifndef AMC_H
 #define AMC_H
 
+#include <string>
+#include "xhal/utils/PyTypes.h"
 #include "xhal/XHALDevice.h"
 
 namespace xhal {
@@ -27,17 +29,17 @@ namespace xhal {
                 /**
                  *  @brief As getOHVFATMask(...) but for all optohybrids specified in ohMask
                  *  @param ohMask A 12 bit number which specifies which optohybrids to read from.  Having a value of 1 in the n^th bit indicates that the n^th optohybrid should be considered.
-                 *  @param ohVfatMaskArray Pointer to an array of length 12.  After the call completes each element will be the bitmask of chip positions determining which chips to use for the optohybrid number corresponding to the element index.
+                 *  @returns a PyListUint32 of length 12 where each element is the bitmask of chip positions determining which chips to use for the optohybrid number corresponding to the element index.
                  */
-                uint32_t getOHVFATMaskMultiLink(uint32_t ohMask, uint32_t * ohVfatMaskArray);
+                PyListUint32 getOHVFATMaskMultiLink(uint32_t ohMask=0xfff);
 
                 /**
                  *  @brief SBIT readout from optohybrid ohN for a number of seconds given by acquireTime; data is written to a file directory specified by outFilePath
                  *  @param ohN Optohybrid optical link number
                  *  @param acquireTime acquisition time on the wall clock in seconds
-                 *  @return An integer from the set {0, 1, EIO}; where 0 indicates successful completion, 1 indicates an RPC error, and EIO is a platform dependent error code representing a file IO error
+                 *  @param outFilePath std::string indicating the filepath that output files should be stored in
                  */
-                uint32_t sbitReadOut(uint32_t ohN, uint32_t acquireTime, char * outFilePath);
+                void sbitReadOut(uint32_t ohN, uint32_t acquireTime, std::string outFilePath);
         }; //End class AMC
     } //End namespace rpc
 } //End namespace xhal

--- a/xhalcore/include/xhal/rpc/amc.h
+++ b/xhalcore/include/xhal/rpc/amc.h
@@ -1,0 +1,13 @@
+#ifndef AMC_H
+#define AMC_H
+
+#include "xhal/rpc/utils.h"
+
+/*! \fn DLLEXPORT uint32_t sbitReadOut(uint32_t ohN, uint32_t acquireTime, uint32_t * approxLiveTime, bool * maxNetworkSizeReached, uint32_t * storedSbits)
+ *  \brief SBIT readout from optohybrid ohN for a number of seconds given by acquireTime; data is written to a file directory specified by outFilePath
+ *  \param ohN Optohybrid optical link number
+ *  \param acquireTime acquisition time on the wall clock in seconds
+ */
+DLLEXPORT uint32_t sbitReadOut(uint32_t ohN, uint32_t acquireTime, char * outFilePath);
+
+#endif

--- a/xhalcore/include/xhal/rpc/amc.h
+++ b/xhalcore/include/xhal/rpc/amc.h
@@ -3,6 +3,21 @@
 
 #include "xhal/rpc/utils.h"
 
+/*! \fn DLLEXPORT uint32_t getOHVFATMask(uint32_t ohN, uint32_t * vfatMask)
+ *  \brief Determines the vfatMask for optohybrid ohN.
+ *  \details Reads the SYNC_ERR_CNT counter for each VFAT on ohN.  If for a given VFAT the counter returns a non-zero value the given VFAT will be masked.
+ *  \param ohN Optohybrid optical link number
+ *  \returns uint32_t where bits [23:0] represent the vfat mask.  If the "error" key exists in the RPC response returns instead overflow (0xFFFFFFFF)
+ */
+DLLEXPORT uint32_t getOHVFATMask(uint32_t ohN);
+
+/*! \fn DLLEXPORT uint32_t getOHVFATMaskMultiLink(uint32_t ohMask, uint32_t * ohVfatMaskArray)
+ *  \brief As getOHVFATMask(...) but for all optohybrids specified in ohMask
+ *  \param ohMask A 12 bit number which specifies which optohybrids to read from.  Having a value of 1 in the n^th bit indicates that the n^th optohybrid should be considered.
+ *  \param ohVfatMaskArray Pointer to an array of length 12.  After the call completes each element will be the bitmask of chip positions determining which chips to use for the optohybrid number corresponding to the element index.
+ */
+DLLEXPORT uint32_t getOHVFATMaskMultiLink(uint32_t ohMask, uint32_t * ohVfatMaskArray);
+
 /*! \fn DLLEXPORT uint32_t sbitReadOut(uint32_t ohN, uint32_t acquireTime, uint32_t * approxLiveTime, bool * maxNetworkSizeReached, uint32_t * storedSbits)
  *  \brief SBIT readout from optohybrid ohN for a number of seconds given by acquireTime; data is written to a file directory specified by outFilePath
  *  \param ohN Optohybrid optical link number

--- a/xhalcore/include/xhal/rpc/amc.h
+++ b/xhalcore/include/xhal/rpc/amc.h
@@ -1,29 +1,45 @@
 #ifndef AMC_H
 #define AMC_H
 
-#include "xhal/rpc/utils.h"
+#include "xhal/XHALDevice.h"
 
-/*! \fn DLLEXPORT uint32_t getOHVFATMask(uint32_t ohN, uint32_t * vfatMask)
- *  \brief Determines the vfatMask for optohybrid ohN.
- *  \details Reads the SYNC_ERR_CNT counter for each VFAT on ohN.  If for a given VFAT the counter returns a non-zero value the given VFAT will be masked.
- *  \param ohN Optohybrid optical link number
- *  \returns uint32_t where bits [23:0] represent the vfat mask.  If the "error" key exists in the RPC response returns instead overflow (0xFFFFFFFF)
- */
-DLLEXPORT uint32_t getOHVFATMask(uint32_t ohN);
+namespace xhal {
+    namespace rpc {
+        class AMC : public xhal::XHALDevice {
+            public:
+                /**
+                 * @brief Default constructor
+                 *
+                 * Parses XML file and loads required modules
+                 * @param board_domain_name domain name of CTP7
+                 * @param address_table_filename XML address table file name
+                 */
+                AMC(const std::string& board_domain_name, const std::string& address_table_filename);
 
-/*! \fn DLLEXPORT uint32_t getOHVFATMaskMultiLink(uint32_t ohMask, uint32_t * ohVfatMaskArray)
- *  \brief As getOHVFATMask(...) but for all optohybrids specified in ohMask
- *  \param ohMask A 12 bit number which specifies which optohybrids to read from.  Having a value of 1 in the n^th bit indicates that the n^th optohybrid should be considered.
- *  \param ohVfatMaskArray Pointer to an array of length 12.  After the call completes each element will be the bitmask of chip positions determining which chips to use for the optohybrid number corresponding to the element index.
- */
-DLLEXPORT uint32_t getOHVFATMaskMultiLink(uint32_t ohMask, uint32_t * ohVfatMaskArray);
+                /**
+                 *  @brief Determines the vfatMask for optohybrid ohN.
+                 *  @details Reads the SYNC_ERR_CNT counter for each VFAT on ohN.  If for a given VFAT the counter returns a non-zero value the given VFAT will be masked.
+                 *  @param ohN Optohybrid optical link number
+                 *  @returns uint32_t where bits [23:0] represent the vfat mask.  If the "error" key exists in the RPC response returns instead overflow (0xFFFFFFFF)
+                 */
+                uint32_t getOHVFATMask(uint32_t ohN);
 
-/*! \fn DLLEXPORT uint32_t sbitReadOut(uint32_t ohN, uint32_t acquireTime, uint32_t * approxLiveTime, bool * maxNetworkSizeReached, uint32_t * storedSbits)
- *  \brief SBIT readout from optohybrid ohN for a number of seconds given by acquireTime; data is written to a file directory specified by outFilePath
- *  \param ohN Optohybrid optical link number
- *  \param acquireTime acquisition time on the wall clock in seconds
- *  \return An integer from the set {0, 1, EIO}; where 0 indicates successful completion, 1 indicates an RPC error, and EIO is a platform dependent error code representing a file IO error
- */
-DLLEXPORT uint32_t sbitReadOut(uint32_t ohN, uint32_t acquireTime, char * outFilePath);
+                /**
+                 *  @brief As getOHVFATMask(...) but for all optohybrids specified in ohMask
+                 *  @param ohMask A 12 bit number which specifies which optohybrids to read from.  Having a value of 1 in the n^th bit indicates that the n^th optohybrid should be considered.
+                 *  @param ohVfatMaskArray Pointer to an array of length 12.  After the call completes each element will be the bitmask of chip positions determining which chips to use for the optohybrid number corresponding to the element index.
+                 */
+                uint32_t getOHVFATMaskMultiLink(uint32_t ohMask, uint32_t * ohVfatMaskArray);
+
+                /**
+                 *  @brief SBIT readout from optohybrid ohN for a number of seconds given by acquireTime; data is written to a file directory specified by outFilePath
+                 *  @param ohN Optohybrid optical link number
+                 *  @param acquireTime acquisition time on the wall clock in seconds
+                 *  @return An integer from the set {0, 1, EIO}; where 0 indicates successful completion, 1 indicates an RPC error, and EIO is a platform dependent error code representing a file IO error
+                 */
+                uint32_t sbitReadOut(uint32_t ohN, uint32_t acquireTime, char * outFilePath);
+        } //End class AMC
+    } //End namespace rpc
+} //End namespace xhal
 
 #endif

--- a/xhalcore/include/xhal/rpc/amc.h
+++ b/xhalcore/include/xhal/rpc/amc.h
@@ -38,7 +38,7 @@ namespace xhal {
                  *  @return An integer from the set {0, 1, EIO}; where 0 indicates successful completion, 1 indicates an RPC error, and EIO is a platform dependent error code representing a file IO error
                  */
                 uint32_t sbitReadOut(uint32_t ohN, uint32_t acquireTime, char * outFilePath);
-        } //End class AMC
+        }; //End class AMC
     } //End namespace rpc
 } //End namespace xhal
 

--- a/xhalcore/include/xhal/rpc/calibration_routines.h
+++ b/xhalcore/include/xhal/rpc/calibration_routines.h
@@ -1,13 +1,15 @@
 #ifndef CALIBRATION_ROUTINES_H
 #define CALIBRATION_ROUTINES_H
 
+#include "xhal/utils/CalParamTypes.h"
+#include "xhal/utils/PyTypes.h"
 #include "xhal/XHALInterface.h"
 
 namespace xhal {
   namespace rpc {
     /**
     * @class CalRoutines
-    * @brief Provides interface to call remote utility methods 
+    * @brief Provides interface to call remote utility methods
     */
     class CalRoutines : public XHALInterface
     {
@@ -22,54 +24,46 @@ namespace xhal {
 
         ~CalRoutines(){}
 
-        //FIXME Add documentation
-        uint32_t checkSbitMappingWithCalPulse(uint32_t ohN, uint32_t vfatN, uint32_t mask, bool useCalPulse, bool currentPulse, uint32_t calScaleFactor, uint32_t nevts, uint32_t L1Ainterval, uint32_t pulseDelay, uint32_t *data);
+        /**
+         * @brief investigates the sbit mapping with the calpulse, can also be used to observe which channels send sbits when the calpulse is not used
+         * @param scanParams an instance of xhal::ParamScan which specifies the scan parameters
+         * @param calPulseParams an instance of xhal::ParamCalPulse which specifies the configuration of the calibration module
+         * @param ttcGenParams an instance of xhal::ParamTtcGen which specifies the configuration of the CTP7 TTC Generator
+         */
+        PyListUint32 checkSbitMappingWithCalPulse(xhal::ParamScan &scanParams, xhal::ParamCalPulse &calPulseParams, xhal::ParamTtcGen &ttcGenParams);
 
-        //FIXME Add documentation
-        uint32_t checkSbitRateWithCalPulse(uint32_t ohN, uint32_t vfatN, uint32_t mask, bool useCalPulse, bool currentPulse, uint32_t calScaleFactor, uint32_t waitTime, uint32_t pulseRate, uint32_t pulseDelay, uint32_t *outDataCTP7Rate, uint32_t *outDataFPGAClusterCntRate, uint32_t *outDataVFATSBits);
+        /**
+         * @brief compares the sbit rate with a known pulse rate with the calpulse, can also be used to measure the sbit rate when the calpulse is not used
+         * @param scanParams an instance of xhal::ParamScan which specifies the scan parameters
+         * @param calPulseParams an instance of xhal::ParamCalPulse which specifies the configuration of the calibration module
+         * @param ttcGenParams an instance of xhal::ParamTtcGen which specifies the configuration of the CTP7 TTC Generator
+         */
+        PyDictVecUint32<std::string> checkSbitRateWithCalPulse(xhal::ParamScan &scanParams, xhal::ParamCalPulse &calPulseParams, xhal::ParamTtcGen &ttcGenParams);
 
         /**
          * @brief Runs a generic scan routine for a specific channel of a VFAT chip
-         *
-         * @param nevts Number of events per scan point
-         * @param ohN Optical link
-         * @param dacMin Min value of scanned variable
-         * @param dacMax Max value of scanned variable
-         * @param dacStep Step parameter
-         * @param ch VFAT channel 
-         * @param useCalPulse Indicates whether to use internal calibration pulses
-         * @param currentPulse Indicates whether to use current or voltage internal calibration pulse
-         * @param calScaleFactor FIXME
-         * @param mask FIXME
-         * @param scanReg Register to scan FIXME: add possible values
-         * @param useUltra Indicates whether to use FW-implemented ultraScan
-         * @param useExtTrig FIXME: do we need both this and useCalPulse?
-         * @param result An array carrying scan results
+         * @param scanParams an instance of xhal::ParamScan which specifies the scan parameters
+         * @param calPulseParams an instance of xhal::ParamCalPulse which specifies the configuration of the calibration module
+         * @returns A PyListUint32 container holding the scan results
          */
-        uint32_t genScan(uint32_t nevts, uint32_t ohN, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep, uint32_t ch, bool useCalPulse, bool currentPulse, uint32_t calScaleFactor, uint32_t mask, char * scanReg, bool useUltra, bool useExtTrig, uint32_t * result);
+        PyListUint32 genScan(xhal::ParamScan &scanParams, xhal::ParamCalPulse &calPulseParams);
 
         /**
          * @brief Runs a generic scan routine on all channels of a VFAT chip
-         *
-         * @param nevts Number of events per scan point
-         * @param ohN Optical link
-         * @param dacMin Min value of scanned variable
-         * @param dacMax Max value of scanned variable
-         * @param dacStep Step parameter
-         * @param useCalPulse Indicates whether to use internal calibration pulses
-         * @param currentPulse Indicates whether to use current or voltage internal calibration pulse
-         * @param calScaleFactor FIXME
-         * @param mask FIXME
-         * @param scanReg Register to scan FIXME: add possible values
-         * @param useUltra Indicates whether to use FW-implemented ultraScan
-         * @param useExtTrig FIXME: do we need both this and useCalPulse?
-         * @param result An array carrying scan results
+         * @param scanParams an instance of xhal::ParamScan which specifies the scan parameters
+         * @param calPulseParams an instance of xhal::ParamCalPulse which specifies the configuration of the calibration module
+         * @returns A PyListUint32 container holding the scan results
          */
-        //FIXME Should we rearrange parameters so they are in the same order as in genScan?
-        uint32_t genChannelScan(uint32_t nevts, uint32_t ohN, uint32_t mask, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep, bool useCalPulse, bool currentPulse, uint32_t calScaleFactor, bool useExtTrig, char * scanReg, bool useUltra, uint32_t * result);
+        PyListUint32 genChannelScan(xhal::ParamScan &scanParams, xhal::ParamCalPulse &calPulseParams);
 
-        //FIXME Add documentation
-        uint32_t sbitRateScan(uint32_t ohN, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep, uint32_t ch, uint32_t maskOh, bool invertVFATPos, char * scanReg, uint32_t waitTime, uint32_t * resultDacVal, uint32_t * resultTrigRate, uint32_t * resultTrigRatePerVFAT, bool isParallel);
+        /**
+         * @brief Measures sbit rate as a function of scanParams.scanReg and reports the trigger rate observed
+         * @param scanParams an instance of xhal::ParamScan which specifies the scan parameters
+         * @param invertVFATPos true (false) firmware uses software (hardware) numbering for VFAT position
+         * @param isParallel true (false) run scan in parallel (series)
+         * @returns A PyDictVecUint32<std::string> container with the keys {"DACVAL","CTP7Rate","VFATRate"} where each key maps to a value of PyListUint32 of all the same length and each element represents respectively the dac value, the rate measured by the CTP7, and the rate measured per VFAT.
+         */
+        PyDictVecUint32<std::string> sbitRateScan(xhal::ParamScan &scanParams, bool invertVFATPos=false, bool isParallel=true);
 
         /**
          * @brief configure TTC generator
@@ -92,8 +86,11 @@ namespace xhal {
          *      L1Ainterval (only for mode 0,1), how often to repeat signals
          *      nPulses how many signals to send (0 is continuous)
          *      enable = true (false) start (stop) the T1Controller for link ohN
+         *
+         * @param ohN Optohybrid optical link number
+         * @param ttcGenParams an instance of xhal::ParamTtcGen which specifies the configuration of the CTP7 TTC Generator
          */
-        uint32_t ttcGenConf(uint32_t ohN, uint32_t mode, uint32_t type, uint32_t pulseDelay, uint32_t L1Ainterval, uint32_t nPulses, bool enable);
+        void ttcGenConf(uint32_t ohN, xhal::ParamTtcGen &ttcGenParams);
 
         /**
          * @brief Toggles TTC behavior
@@ -101,7 +98,7 @@ namespace xhal {
          * v3  electronics: enable = true (false) ignore (take) ttc commands from backplane for this AMC
          * v2b electronics: enable = true (false) start (stop) the T1Controller for link ohN
          */
-        uint32_t ttcGenToggle(uint32_t ohN, bool enable);
+        void ttcGenToggle(uint32_t ohN, bool enable);
     };
   }
 }

--- a/xhalcore/include/xhal/rpc/calibration_routines.h
+++ b/xhalcore/include/xhal/rpc/calibration_routines.h
@@ -20,7 +20,10 @@ namespace xhal {
          * Loads the neccessary remote modules
          * @param board_domain_name domain name of CTP7
          */
-        CalRoutines(const std::string& board_domain_name):xhal::XHALInterface(board_domain_name){this->loadModule("calibration_routines", "calibration_routines v1.0.1");}
+        CalRoutines(const std::string& board_domain_name):xhal::XHALInterface(board_domain_name){
+            m_map_modName_modVer["calibration_routines"]="calibration_routines v1.0.1";
+            this->loadModule("calibration_routines", "calibration_routines v1.0.1");
+        }
 
         ~CalRoutines(){}
 

--- a/xhalcore/include/xhal/rpc/daq_monitor.h
+++ b/xhalcore/include/xhal/rpc/daq_monitor.h
@@ -19,7 +19,10 @@ namespace xhal {
          * Loads the neccessary remote modules
          * @param board_domain_name domain name of CTP7
          */
-        DaqMonitor(const std::string& board_domain_name):xhal::XHALInterface(board_domain_name){this->loadModule("amc", "amc v1.0.1");}
+        DaqMonitor(const std::string& board_domain_name):xhal::XHALInterface(board_domain_name){
+            m_map_modName_modVer["amc"]="amc v1.0.1";
+            this->loadModule("amc", "amc v1.0.1");
+        }
 
         ~DaqMonitor(){}
 

--- a/xhalcore/include/xhal/rpc/daq_monitor.h
+++ b/xhalcore/include/xhal/rpc/daq_monitor.h
@@ -8,7 +8,7 @@ namespace xhal {
   namespace rpc {
     /**
     * @class DaqMonitor
-    * @brief Provides interface to call remote utility methods 
+    * @brief Provides interface to call remote utility methods
     */
     class DaqMonitor : public XHALInterface
     {
@@ -69,6 +69,16 @@ namespace xhal {
          * @return an array of monitoring values
          */
         PyListUint32 getmonOHmain(uint32_t noh = 12);
+
+        /**
+         * @brief get an array of values for OH SCA monitoring table
+         *
+         * @param noh Number of expected optical links, default value 12
+         * @param ohMask A 12 bit number which specifies which optohybrids to read from.  Having a value of 1 in the n^th bit indicates that the n^th optohybrid should be considered.
+         * @return an map of monitoring values
+         */
+        //PyDictVecUint32<int> getmonOHSCAmain(uint32_t noh = 12, uint32_t ohMask = 0xfff);
+        NestedPyDict<int,PyDictUint32<std::string> > getmonOHSCAmain(uint32_t noh = 12, uint32_t ohMask = 0xfff);
     };
   }
 }

--- a/xhalcore/include/xhal/rpc/daq_monitor.h
+++ b/xhalcore/include/xhal/rpc/daq_monitor.h
@@ -75,9 +75,8 @@ namespace xhal {
          *
          * @param noh Number of expected optical links, default value 12
          * @param ohMask A 12 bit number which specifies which optohybrids to read from.  Having a value of 1 in the n^th bit indicates that the n^th optohybrid should be considered.
-         * @return an map of monitoring values
+         * @return a nested map of monitoring values, outer key is ohN, value is a PyDictUint32<std::string> which maps register to value
          */
-        //PyDictVecUint32<int> getmonOHSCAmain(uint32_t noh = 12, uint32_t ohMask = 0xfff);
         NestedPyDict<int,PyDictUint32<std::string> > getmonOHSCAmain(uint32_t noh = 12, uint32_t ohMask = 0xfff);
     };
   }

--- a/xhalcore/include/xhal/rpc/optohybrid.h
+++ b/xhalcore/include/xhal/rpc/optohybrid.h
@@ -1,7 +1,11 @@
 #ifndef OPTOHYBRID_H
 #define OPTOHYBRID_H
 
+#include <string>
+#include "xhal/utils/CalParamTypes.h"
+#include "xhal/utils/PyTypes.h"
 #include "xhal/XHALDevice.h"
+
 namespace xhal {
   namespace rpc {
     class Optohybrid : public xhal::XHALDevice {
@@ -16,13 +20,13 @@ namespace xhal {
       Optohybrid(const std::string& board_domain_name, const std::string& address_table_filename);
 
       //FIXME provide documentation
-      uint32_t broadcastRead(uint32_t ohN, char * regName, uint32_t vfatMask, uint32_t * result);
-      uint32_t broadcastWrite(uint32_t ohN, char * regName, uint32_t value, uint32_t vfatMask);
-      uint32_t configureScanModule(uint32_t ohN, uint32_t vfatN, uint32_t scanmode, bool useUltra, uint32_t vfatMask, uint32_t ch, uint32_t nevts, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep);
-      uint32_t printScanConfiguration(uint32_t ohN, bool useUltra);
-      uint32_t startScanModule(uint32_t ohN, bool useUltra);
-      uint32_t getUltraScanResults(uint32_t ohN, uint32_t nevts, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep, uint32_t * result);
-      uint32_t stopCalPulse2AllChannels(uint32_t ohN, uint32_t mask, uint32_t ch_min, uint32_t ch_max);
+      PyListUint32 broadcastRead(uint32_t ohN, std::string &regName, uint32_t vfatMask);
+      void broadcastWrite(uint32_t ohN, std::string &regName, uint32_t value, uint32_t vfatMask);
+      void configureScanModule(xhal::ParamScan &scanParams, uint32_t scanmode);
+      void printScanConfiguration(uint32_t ohN, bool useUltra);
+      void startScanModule(uint32_t ohN, bool useUltra);
+      PyListUint32 getUltraScanResults(xhal::ParamScan &scanParams);
+      void stopCalPulse2AllChannels(uint32_t ohN, uint32_t mask, uint32_t ch_min, uint32_t ch_max);
     };//end class Optohybrid
   }//end namespace rpc
 }//end namespace xhal

--- a/xhalcore/include/xhal/rpc/utils.h
+++ b/xhalcore/include/xhal/rpc/utils.h
@@ -11,7 +11,7 @@ namespace xhal {
   namespace rpc {
     /**
     * @class Utils
-    * @brief Provides interface to call remote utility methods 
+    * @brief Provides interface to call remote utility methods
     */
     class Utils : public XHALInterface
     {
@@ -22,12 +22,15 @@ namespace xhal {
          * Loads the neccessary remote modules
          * @param board_domain_name domain name of CTP7
          */
-        Utils(const std::string& board_domain_name):xhal::XHALInterface(board_domain_name){this->loadModule("utils", "utils v1.0.1");}
+        Utils(const std::string& board_domain_name):xhal::XHALInterface(board_domain_name){
+            m_map_modName_modVer["utils"]="utils v1.0.1";
+            this->loadModule("utils", "utils v1.0.1");
+        }
         ~Utils(){}
         uint32_t update_atdb(char * xmlfilename);
         uint32_t getRegInfoDB(char * regName);
-    }; 
- 
+    };
+
   }
 }
 #endif

--- a/xhalcore/include/xhal/rpc/vfat3.h
+++ b/xhalcore/include/xhal/rpc/vfat3.h
@@ -15,7 +15,7 @@ namespace xhal {
        * @param address_table_filename XML address table file name
        */
       VFAT3(const std::string& board_domain_name, const std::string& address_table_filename);
-       
+
       //FIXME provide docs
       /**
        * @brief load configuration parameters to VFAT3 chips

--- a/xhalcore/include/xhal/rpc/vfat3.h
+++ b/xhalcore/include/xhal/rpc/vfat3.h
@@ -22,6 +22,22 @@ namespace xhal {
        */
       uint32_t configureVFAT3s(uint32_t ohN, uint32_t vfatMask);
 
+       /**
+        *  @brief configures all unmasked VFATs on ohN for ADC Monitoring of the DAC specified by dacSelect.  See the VFAT3 manual for possible values of dacSelect.
+        *  @param ohN Optohybrid optical link number
+        *  @param vfatMask Bitmask of chip positions determining which chips to use
+        *  @param dacSelect the monitoring selection for the VFAT3 ADC, possible values are [0,16] and [32,41].  See VFAT3 manual for details
+        */
+      uint32_t configureVFAT3DacMonitor(uint32_t ohN, uint32_t vfatMask, uint32_t dacSelect);
+
+      /**
+       *  @brief configures all unmasked VFATs on ohN for ADC Monitoring of the DAC specified by dacSelect.  See the VFAT3 manual for possible values of dacSelect.
+       *  @param ohMask A 12 bit number which specifies which optohybrids to read from.  Having a value of 1 in the n^th bit indicates that the n^th optohybrid should be considered.
+       *  @param ohVfatMaskArray Pointer to an array of length 12.  Each element is the bitmask of chip positions determining which chips to use for the optohybrid number corresponding to the element index.
+       *  @param dacSelect the monitoring selection for the VFAT3 ADC, possible values are [0,16] and [32,41].  See VFAT3 manual for details
+       */
+      uint32_t configureVFAT3DacMonitorMultiLink(uint32_t ohMask, uint32_t *ohVfatMaskArray, uint32_t dacSelect);
+
       /**
        *  @brief reads channel registers of all unmasked vfats on ohN
        *  @param ohN Optohybrid optical link number
@@ -29,6 +45,24 @@ namespace xhal {
        *  @param chanRegData array pointer for channel register data with 3072 entries, the (vfat,chan) pairing determines the array index via: idx = vfat*128 + chan
        */
       uint32_t getChannelRegistersVFAT3(uint32_t ohN, uint32_t vfatMask, uint32_t *chanRegData);
+
+      /**
+       *  @brief Reads the ADC value from all unmasked VFATs
+       *  @param adcData pointer to the array containing the ADC results; length of array is expected to be 24
+       *  @param ohN Optohybrid optical link number
+       *  @param useExtRefADC true (false) read the ADC1 (ADC0) which uses an external (internal) reference
+       *  @param vfatMask Bitmask of chip positions determining which chips to use
+       */
+      uint32_t readVFAT3ADC(uint32_t ohN, uint32_t *adcData, bool useExtRefADC=false, uint32_t vfatMask=0xFF000000);
+
+      /**
+       *  @brief As readVFAT3ADC(...) but for all optical links specified in ohMask on the AMC
+       *  @param ohMask A 12 bit number which specifies which optohybrids to read from.  Having a value of 1 in the n^th bit indicates that the n^th optohybrid should be considered.
+       *  @param ohVfatMaskArray Pointer to an array of length 12.  Each element is the bitmask of chip positions determining which chips to use for the optohybrid number corresponding to the element index.
+       *  @param adcDataAll pointer to the array containing the ADC results; length of array is expected to be 12*24=288
+       *  @param useExtRefADC true (false) read the ADC1 (ADC0) which uses an external (internal) reference
+       */
+      uint32_t readVFAT3ADCMultiLink(uint32_t ohMask, uint32_t *ohVfatMaskArray, uint32_t *adcDataAll, bool useExtRefADC=false);
 
       /**
        *  @brief sets all vfat3 channel registers

--- a/xhalcore/include/xhal/rpc/vfat3.h
+++ b/xhalcore/include/xhal/rpc/vfat3.h
@@ -2,6 +2,7 @@
 #define VFAT3_H
 
 #include "xhal/XHALDevice.h"
+#include "xhal/utils/PyTypes.h"
 
 namespace xhal {
   namespace rpc {
@@ -20,7 +21,7 @@ namespace xhal {
       /**
        * @brief load configuration parameters to VFAT3 chips
        */
-      uint32_t configureVFAT3s(uint32_t ohN, uint32_t vfatMask);
+      void configureVFAT3s(uint32_t ohN, uint32_t vfatMask);
 
        /**
         *  @brief configures all unmasked VFATs on ohN for ADC Monitoring of the DAC specified by dacSelect.  See the VFAT3 manual for possible values of dacSelect.
@@ -28,62 +29,62 @@ namespace xhal {
         *  @param vfatMask Bitmask of chip positions determining which chips to use
         *  @param dacSelect the monitoring selection for the VFAT3 ADC, possible values are [0,16] and [32,41].  See VFAT3 manual for details
         */
-      uint32_t configureVFAT3DacMonitor(uint32_t ohN, uint32_t vfatMask, uint32_t dacSelect);
+      void configureVFAT3DacMonitor(uint32_t ohN, uint32_t vfatMask, uint32_t dacSelect);
 
       /**
        *  @brief configures all unmasked VFATs on ohN for ADC Monitoring of the DAC specified by dacSelect.  See the VFAT3 manual for possible values of dacSelect.
        *  @param ohMask A 12 bit number which specifies which optohybrids to read from.  Having a value of 1 in the n^th bit indicates that the n^th optohybrid should be considered.
-       *  @param ohVfatMaskArray Pointer to an array of length 12.  Each element is the bitmask of chip positions determining which chips to use for the optohybrid number corresponding to the element index.
+       *  @param ohVfatMaskArray PyListUint32 of size 12.  Each element is the bitmask of chip positions determining which chips to use for the optohybrid number corresponding to the element index.
        *  @param dacSelect the monitoring selection for the VFAT3 ADC, possible values are [0,16] and [32,41].  See VFAT3 manual for details
        */
-      uint32_t configureVFAT3DacMonitorMultiLink(uint32_t ohMask, uint32_t *ohVfatMaskArray, uint32_t dacSelect);
+      void configureVFAT3DacMonitorMultiLink(uint32_t ohMask, PyListUint32 &ohVfatMaskArray, uint32_t dacSelect);
 
       /**
        *  @brief reads channel registers of all unmasked vfats on ohN
        *  @param ohN Optohybrid optical link number
        *  @param vfatMask Bitmask of chip positions determining which chips to use
-       *  @param chanRegData array pointer for channel register data with 3072 entries, the (vfat,chan) pairing determines the array index via: idx = vfat*128 + chan
+       *  @returns A PyListUint32 of size 3072 containing channel register data, the (vfat,chan) pairing determines the index via: idx = vfat*128 + chan
        */
-      uint32_t getChannelRegistersVFAT3(uint32_t ohN, uint32_t vfatMask, uint32_t *chanRegData);
+      PyListUint32 getChannelRegistersVFAT3(uint32_t ohN, uint32_t vfatMast);
 
       /**
        *  @brief Reads the ADC value from all unmasked VFATs
-       *  @param adcData pointer to the array containing the ADC results; length of array is expected to be 24
        *  @param ohN Optohybrid optical link number
        *  @param useExtRefADC true (false) read the ADC1 (ADC0) which uses an external (internal) reference
        *  @param vfatMask Bitmask of chip positions determining which chips to use
+       *  @returns PyListUint32 of size 24 containing the ADC results
        */
-      uint32_t readVFAT3ADC(uint32_t ohN, uint32_t *adcData, bool useExtRefADC=false, uint32_t vfatMask=0xFF000000);
+      PyListUint32 readVFAT3ADC(uint32_t ohN, bool useExtRefADC=false, uint32_t vfatMask=0xFF000000);
 
       /**
        *  @brief As readVFAT3ADC(...) but for all optical links specified in ohMask on the AMC
        *  @param ohMask A 12 bit number which specifies which optohybrids to read from.  Having a value of 1 in the n^th bit indicates that the n^th optohybrid should be considered.
-       *  @param ohVfatMaskArray Pointer to an array of length 12.  Each element is the bitmask of chip positions determining which chips to use for the optohybrid number corresponding to the element index.
-       *  @param adcDataAll pointer to the array containing the ADC results; length of array is expected to be 12*24=288
+       *  @param ohVfatMaskArray PyListUint32 of size 12.  Each element is the bitmask of chip positions determining which chips to use for the optohybrid number corresponding to the element index.
        *  @param useExtRefADC true (false) read the ADC1 (ADC0) which uses an external (internal) reference
+       *  @returns PyListUint32 of size 12*24=288 containing the ADC results
        */
-      uint32_t readVFAT3ADCMultiLink(uint32_t ohMask, uint32_t *ohVfatMaskArray, uint32_t *adcDataAll, bool useExtRefADC=false);
+      PyListUint32 readVFAT3ADCMultiLink(uint32_t ohMask, PyListUint32 &ohVfatMaskArray, bool useExtRefADC=false);
 
       /**
        *  @brief sets all vfat3 channel registers
        *  @param ohN Optohybrid optical link number
        *  @param vfatMask Bitmask of chip positions determining which chips to use
-       *  @param calEnable array pointer for calEnable with 3072 entries, the (vfat,chan) pairing determines the array index via: idx = vfat*128 + chan
+       *  @param calEnable PyListUint32 for calEnable with 3072 entries, the (vfat,chan) pairing determines the index via: idx = vfat*128 + chan
        *  @param masks as calEnable but for channel masks
        *  @param trimARM as calEnable but for arming comparator trim value
        *  @param trimARMPol as calEnable but for arming comparator trim polarity
        *  @param trimZCC as calEnable but for zero crossing comparator trim value
        *  @param trimZCCPol as calEnable but for zero crossing comparator trim polarity
        */
-      uint32_t setChannelRegistersVFAT3(uint32_t ohN, uint32_t vfatMask, uint32_t *calEnable, uint32_t *masks, uint32_t *trimARM, uint32_t *trimARMPol, uint32_t *trimZCC, uint32_t *trimZCCPol);
+      void setChannelRegistersVFAT3(uint32_t ohN, uint32_t vfatMask, PyListUint32 &calEnable, PyListUint32 &masks, PyListUint32 &trimARM, PyListUint32 &trimARMPol, PyListUint32 &trimZCC, PyListUint32 &trimZCCPol);
 
       /**
        *  @brief sets all vfat3 channel registers using a single channel register array
        *  @param ohN Optohybrid optical link number
        *  @param vfatMask Bitmask of chip positions determining which chips to use
-       *  @param chanRegData array pointer for channel register data with 3072 entries, the (vfat,chan) pairing determines the array index via: idx = vfat*128 + chan
+       *  @param chanRegData PyListUint32 of size 3072 containing channel register data, the (vfat,chan) pairing determines the index via: idx = vfat*128 + chan
        */
-      uint32_t setChannelRegistersVFAT3Simple(uint32_t ohN, uint32_t vfatMask, uint32_t *chanRegData);
+      void setChannelRegistersVFAT3Simple(uint32_t ohN, uint32_t vfatMask, PyListUint32 &chanRegData);
     };//end class VFAT3
   }//end namespace rpc
 }//end namespace xhal

--- a/xhalcore/include/xhal/utils/CalParamTypes.h
+++ b/xhalcore/include/xhal/utils/CalParamTypes.h
@@ -1,0 +1,81 @@
+#ifndef CAL_UTILS_H
+#define CAL_UTILS_H
+
+namespace xhal {
+    struct ParamScan{
+        //Hardware selection
+        uint32_t ohN;
+        uint32_t ohMask;
+        uint32_t vfatN;
+        uint32_t vfatMask;
+        uint32_t chan;      //channel of interest
+
+        //Params
+        bool useUltra;
+        bool useExtTrig;
+
+        uint32_t dacMax;    //Maximum dac value
+        uint32_t dacMin;    //Minimum dac value
+        uint32_t dacSelect; //DAC to use for Monitoring
+        uint32_t dacStep;   //step size for dac
+        uint32_t nevts;     //Number of events
+        uint32_t waitTime;  //unit of time; uints depend on function
+
+        string scanReg;     //Register to scan against
+
+        ParamScan(){
+            useUltra = true;
+            useExtTrig = false;
+
+            dacMax=254;
+            dacMin=0;
+            dacStep=1;
+            nevts=100;
+        }
+    }; //End ParamScan
+
+    struct ParamCalPulse{
+        bool enable; //true (false) turn on (off) calpulse
+        bool isCurrent; //true (false) is current injection (voltage pulse)
+
+        uint32_t duration; //duration in BX's (CFG_CAL_DUR)
+        uint32_t extVoltStep; //External voltage step 0->disable; 1->enable (CFG_CAL_EXT)
+        uint32_t height; //height of calpulse (CFG_CAL_DAC)
+        uint32_t phase; //phase of calpulse (CFG_CAL_PHI)
+        uint32_t polarity; //polarity of calpulse 0->pos; 1->neg (CFG_CAL_SEL_POL)
+        uint32_t scaleFactor; //current pulse scale factor (CFG_CAL_FS)
+
+        SetupCalPulse(){
+            enable = false;
+            isCurrent = false;
+
+            duration = 0x1ff;
+            extVoltStep = 0x0;
+            height = 0x0;
+            phase = 0x0;
+            polarity = 0x0;
+            scaleFactor = 0x0;
+        }
+    }; //End ParamCalPulse
+
+    struct ParamTtcGen{
+        bool enable;
+
+        uint32_t L1Ainterval;
+        uint32_t mode;
+        uint32_t nPulses;
+        uint32_t pulseDelay;
+        uint32_t pulseRate;
+        uint32_t type;
+
+        ParamTtcGen(){
+            enable = false;
+
+            L1Ainterval = 250;
+            pulseDelay = 40;
+            pulseRate = 0;
+        }
+    }; //End ParamTtcGen
+
+} //End namespace xhal
+#endif

--- a/xhalcore/include/xhal/utils/CalParamTypes.h
+++ b/xhalcore/include/xhal/utils/CalParamTypes.h
@@ -1,7 +1,33 @@
 #ifndef CAL_UTILS_H
 #define CAL_UTILS_H
 
+#include <string>
+
 namespace xhal {
+    struct ParamCalPulse{
+        bool enable; //true (false) turn on (off) calpulse
+        bool isCurrent; //true (false) is current injection (voltage pulse)
+
+        uint32_t duration; //duration in BX's (CFG_CAL_DUR)
+        uint32_t extVoltStep; //External voltage step 0->disable; 1->enable (CFG_CAL_EXT)
+        uint32_t height; //height of calpulse (CFG_CAL_DAC)
+        uint32_t phase; //phase of calpulse (CFG_CAL_PHI)
+        uint32_t polarity; //polarity of calpulse 0->pos; 1->neg (CFG_CAL_SEL_POL)
+        uint32_t scaleFactor; //current pulse scale factor (CFG_CAL_FS)
+
+        ParamCalPulse(){
+            enable = false;
+            isCurrent = false;
+
+            duration = 0x1ff;
+            extVoltStep = 0x0;
+            height = 0x0;
+            phase = 0x0;
+            polarity = 0x0;
+            scaleFactor = 0x0;
+        }
+    }; //End ParamCalPulse
+
     struct ParamScan{
         //Hardware selection
         uint32_t ohN;
@@ -21,9 +47,12 @@ namespace xhal {
         uint32_t nevts;     //Number of events
         uint32_t waitTime;  //unit of time; uints depend on function
 
-        string scanReg;     //Register to scan against
+        std::string scanReg;     //Register to scan against
 
         ParamScan(){
+            vfatMask = 0x0;
+            ohMask = 0xfff;
+
             useUltra = true;
             useExtTrig = false;
 
@@ -33,30 +62,6 @@ namespace xhal {
             nevts=100;
         }
     }; //End ParamScan
-
-    struct ParamCalPulse{
-        bool enable; //true (false) turn on (off) calpulse
-        bool isCurrent; //true (false) is current injection (voltage pulse)
-
-        uint32_t duration; //duration in BX's (CFG_CAL_DUR)
-        uint32_t extVoltStep; //External voltage step 0->disable; 1->enable (CFG_CAL_EXT)
-        uint32_t height; //height of calpulse (CFG_CAL_DAC)
-        uint32_t phase; //phase of calpulse (CFG_CAL_PHI)
-        uint32_t polarity; //polarity of calpulse 0->pos; 1->neg (CFG_CAL_SEL_POL)
-        uint32_t scaleFactor; //current pulse scale factor (CFG_CAL_FS)
-
-        SetupCalPulse(){
-            enable = false;
-            isCurrent = false;
-
-            duration = 0x1ff;
-            extVoltStep = 0x0;
-            height = 0x0;
-            phase = 0x0;
-            polarity = 0x0;
-            scaleFactor = 0x0;
-        }
-    }; //End ParamCalPulse
 
     struct ParamTtcGen{
         bool enable;
@@ -76,6 +81,6 @@ namespace xhal {
             pulseRate = 0;
         }
     }; //End ParamTtcGen
-
 } //End namespace xhal
+
 #endif

--- a/xhalcore/include/xhal/utils/CalParamTypes.h
+++ b/xhalcore/include/xhal/utils/CalParamTypes.h
@@ -78,7 +78,18 @@ namespace xhal {
 
             L1Ainterval = 250;
             pulseDelay = 40;
-            pulseRate = 0;
+            pulseRate = 40079000 / L1Ainterval;
+        }
+
+        uint32_t calcRate(){
+            if(L1Ainterval > 0){
+                pulseRate = 40079000 / L1Ainterval;
+            }
+            else{
+                pulseRate = 0;
+            }
+
+            return pulseRate;
         }
     }; //End ParamTtcGen
 } //End namespace xhal

--- a/xhalcore/include/xhal/utils/PyTypes.h
+++ b/xhalcore/include/xhal/utils/PyTypes.h
@@ -3,5 +3,7 @@
 #include <map>
 
 typedef std::vector<uint32_t> PyListUint32;
-typedef std::map<std::string, PyListUint32> PyDictVecUint32;
-
+template <class T>
+using PyDictUint32 = std::map<T,uint32_t>; //Now PyDictUint32 is a typedef for std::map<T, uint32_t>
+template <class T>
+using PyDictVecUint32 = std::map<T, PyListUint32>; //now PyDictVecUint32 is a typedef for std::map<T, PyListUint32>

--- a/xhalcore/include/xhal/utils/PyTypes.h
+++ b/xhalcore/include/xhal/utils/PyTypes.h
@@ -3,7 +3,15 @@
 #include <map>
 
 typedef std::vector<uint32_t> PyListUint32;
+
+//this is a typedef for std::map<T, uint32_t>
 template <class T>
 using PyDictUint32 = std::map<T,uint32_t>; //Now PyDictUint32 is a typedef for std::map<T, uint32_t>
+
+//this is a typedef for std::map<T, PyListUint32>
 template <class T>
-using PyDictVecUint32 = std::map<T, PyListUint32>; //now PyDictVecUint32 is a typedef for std::map<T, PyListUint32>
+using PyDictVecUint32 = std::map<T, PyListUint32>;
+
+//this is a typedef for std::map<T, M>
+template <class T, class M>
+using NestedPyDict std::map<T,M>

--- a/xhalcore/include/xhal/utils/PyTypes.h
+++ b/xhalcore/include/xhal/utils/PyTypes.h
@@ -14,4 +14,4 @@ using PyDictVecUint32 = std::map<T, PyListUint32>;
 
 //this is a typedef for std::map<T, M>
 template <class T, class M>
-using NestedPyDict std::map<T,M>
+using NestedPyDict = std::map<T,M>;

--- a/xhalcore/include/xhal/utils/XHALXMLParser.h
+++ b/xhalcore/include/xhal/utils/XHALXMLParser.h
@@ -3,7 +3,7 @@
  * XML parser for XHAL library. Parses the XML address table and store results in unordered map of (regName, Node)
  *
  * @author Mykhailo Dalchenko
- * @version 1.0 
+ * @version 1.0
  */
 
 
@@ -14,7 +14,12 @@
 #include <string>
 #include <iostream>
 #include <unordered_map>
+#ifdef __ARM_ARCH_7A__ //do not include boost::optional
+//#ifdef __arm__
+#include <experimental/optional>
+#else
 #include <boost/optional.hpp>
+#endif
 
 #include <xercesc/util/PlatformUtils.hpp>
 #include <xercesc/util/XMLString.hpp>
@@ -61,9 +66,9 @@ namespace xhal {
          * @param xmlFile address table file name
          */
         XHALXMLParser(const std::string& xmlFile);
-      
+
         ~XHALXMLParser();
-      
+
         /**
          * @brief sets amount of logging/debugging information to display
          * @param loglevel:
@@ -81,16 +86,24 @@ namespace xhal {
         /**
          * @brief returns node object by its name or nothing if name is not found
          */
+#ifdef __ARM_ARCH_7A__
+        std::experimental::optional<xhal::utils::Node> getNode(const char* nodeName);
+#else
         boost::optional<xhal::utils::Node> getNode(const char* nodeName);
+#endif
         /**
          * @brief not implemented
          */
+#ifdef __ARM_ARCH_7A__
+        std::experimental::optional<xhal::utils::Node> getNodeFromAddress(const uint32_t nodeAddress);
+#else
         boost::optional<xhal::utils::Node> getNodeFromAddress(const uint32_t nodeAddress);
+#endif
         /**
          * @brief return all nodes
          */
         std::unordered_map<std::string,xhal::utils::Node> getAllNodes();
-    
+
       private:
         std::string m_xmlFile;
         log4cplus::Logger m_logger;
@@ -100,7 +113,7 @@ namespace xhal {
         xercesc::DOMNode* m_node;
         xercesc::DOMNodeList* children;
         static int index;
-    
+
         /**
          * @brief fills custom node object
          */
@@ -108,7 +121,11 @@ namespace xhal {
         /**
          * @brief returns node attribute value by its name if found
          */
+#ifdef __ARM_ARCH_7A__
+        std::experimental::optional<std::string> getAttVal(xercesc::DOMNode * t_node, const char * attname);
+#else
         boost::optional<std::string> getAttVal(xercesc::DOMNode * t_node, const char * attname);
+#endif
         /**
          * @brief converts string representation of hex, binary or decimal number to an integer
          */

--- a/xhalcore/src/common/XHALDevice.cpp
+++ b/xhalcore/src/common/XHALDevice.cpp
@@ -1,6 +1,6 @@
 #include "xhal/XHALDevice.h"
 
-xhal::XHALDevice::XHALDevice(const std::string& board_domain_name, const std::string& address_table_filename): 
+xhal::XHALDevice::XHALDevice(const std::string& board_domain_name, const std::string& address_table_filename):
   xhal::XHALInterface(board_domain_name),
   m_address_table_filename(address_table_filename)
 {
@@ -10,8 +10,9 @@ xhal::XHALDevice::XHALDevice(const std::string& board_domain_name, const std::st
   DEBUG("XHALXML parser created");
   m_parser->setLogLevel(2);
   m_parser->parseXML();
-  this->loadModule("memory","memory v1.0.1");
-  this->loadModule("extras","extras v1.0.1");
+  m_map_modName_modVer["memory"]="memory v1.0.1";
+  m_map_modName_modVer["extras"]="extras v1.0.1";
+  this->loadStoredModules();
 }
 
 void xhal::XHALDevice::reconnect()
@@ -41,7 +42,7 @@ uint32_t xhal::XHALDevice::readReg(std::string regName)
     uint32_t result;
     if (rsp.get_key_exists("error"))
     {
-      ERROR("RPC response returned error, readReg failed"); 
+      ERROR("RPC response returned error, readReg failed");
       throw xhal::utils::XHALException("Error during register access");
     } else {
       try{
@@ -57,7 +58,7 @@ uint32_t xhal::XHALDevice::readReg(std::string regName)
     DEBUG("RESULT after applying mask: " << std::hex << result);
     for (int i = 0; i < 32; i++)
     {
-      if (mask & 1) 
+      if (mask & 1)
       {
         break;
       }else {
@@ -85,7 +86,7 @@ uint32_t xhal::XHALDevice::readReg(uint32_t address)
   uint32_t result;
   if (rsp.get_key_exists("error"))
   {
-    ERROR("RPC response returned error, readReg failed"); 
+    ERROR("RPC response returned error, readReg failed");
     throw xhal::utils::XHALException("Error during register access");
   } else {
     try{
@@ -98,7 +99,7 @@ uint32_t xhal::XHALDevice::readReg(uint32_t address)
   //result = result & mask;
   //for (int i = 0; i < 32; i++)
   //{
-  //  if (result & 0x01) 
+  //  if (result & 0x01)
   //  {
   //    break;
   //  }else {
@@ -125,7 +126,7 @@ void xhal::XHALDevice::writeReg(std::string regName, uint32_t value)
       STANDARD_CATCH;
       if (rsp.get_key_exists("error"))
       {
-        ERROR("RPC response returned error, writeReg failed"); 
+        ERROR("RPC response returned error, writeReg failed");
         throw xhal::utils::XHALException("Error during register access");
       }
     } else {
@@ -134,7 +135,7 @@ void xhal::XHALDevice::writeReg(std::string regName, uint32_t value)
       uint32_t mask = m_node.mask;
       for (int i = 0; i < 32; i++)
       {
-        if (mask & 1) 
+        if (mask & 1)
         {
           break;
         } else {
@@ -153,7 +154,7 @@ void xhal::XHALDevice::writeReg(std::string regName, uint32_t value)
       STANDARD_CATCH;
       if (rsp.get_key_exists("error"))
       {
-        ERROR("RPC response returned error, writeReg failed"); 
+        ERROR("RPC response returned error, writeReg failed");
         throw xhal::utils::XHALException("Error during register access");
       }
     }

--- a/xhalcore/src/common/XHALDevice.cpp
+++ b/xhalcore/src/common/XHALDevice.cpp
@@ -19,8 +19,7 @@ void xhal::XHALDevice::reconnect()
 {
   if (!isConnected){
     this->connect();
-    this->loadModule("memory","memory v1.0.1");
-    this->loadModule("extras","extras v1.0.1");
+    this->loadStoredModules();
   } else {
     ERROR("Interface already connected. Reconnection failed");
     throw xhal::utils::XHALRPCException("RPC exception: Interface already connected. Reconnection failed");

--- a/xhalcore/src/common/XHALInterface.cpp
+++ b/xhalcore/src/common/XHALInterface.cpp
@@ -57,12 +57,24 @@ void xhal::XHALInterface::disconnect()
     ERROR("Caught exception: " << e.message.c_str());
     throw xhal::utils::XHALRPCException("RPC exception: " + e.message);
   }
+  this->loadStoredModules();
 }
 
 void xhal::XHALInterface::loadModule(const std::string& module_name, const std::string& module_version)
 {
   try {
     ASSERT(rpc.load_module(module_name, module_version));
+  }
+  STANDARD_CATCH;
+  m_map_modName_modVer[module_name]=module_version;
+}
+
+void xhal::XHALInterface::loadStoredModules()
+{
+  try {
+    for(auto modIter = m_map_modName_modVer.begin(); modIter != m_map_modName_modVer.end(); ++modIter){
+      this->loadModule((*modIter).first,(*modIter).second);
+    } //End Loop over m_map_modName_modVer
   }
   STANDARD_CATCH;
 }

--- a/xhalcore/src/common/python_wrappers/XHALInterface_python.cpp
+++ b/xhalcore/src/common/python_wrappers/XHALInterface_python.cpp
@@ -81,18 +81,22 @@ BOOST_PYTHON_MODULE(xhalpy){
   register_exception_translator<xhal::utils::XHALRPCException>(&translate_XHALRPCException);
   register_exception_translator<xhal::utils::XHALRPCNotConnectedException>(&translate_XHALRPCNotConnectedException);
 
-  class_<xhal::XHALInterface>("XHALInterface", init<const std::string&>())
+  /*class_<xhal::XHALInterface>("XHALInterface", init<const std::string&>())
     .def("connect",&xhal::XHALInterface::connect)
     .def("loadModule",&xhal::XHALInterface::loadModule)
-    .def("setLogLevel",&xhal::XHALInterface::setLogLevel);
+    .def("setLogLevel",&xhal::XHALInterface::setLogLevel);*/
 
   class_<xhal::XHALDevice, bases<xhal::XHALInterface> >("XHALDevice", init<const std::string&, const std::string&>())
+  class_<xhal::XHALDevice>("XHALDevice", init<const std::string&, const std::string&>())
+    .def("connect",&xhal::XHALDevice::connect)
     .def("disconnect",&xhal::XHALDevice::disconnect)
     .def("getBlock",&xhal::XHALDevice::getBlock)
     .def("getList",&xhal::XHALDevice::getList)
+    .def("loadModule",&xhal::XHALDevice::loadModule)
     .def("readReg",readReg_byname)
     .def("readReg",readReg_byaddress)
     .def("reconnect",&xhal::XHALDevice::reconnect)
+    .def("setLogLevel",&xhal::XHALDevice::setLogLevel)
     .def("writeReg",&xhal::XHALDevice::writeReg);
 
   class_<PyListUint32>("PyListUint32")
@@ -118,7 +122,11 @@ BOOST_PYTHON_MODULE(xhalpy){
     .def("getOHVFATMaskMultiLink",&xhal::rpc::AMC::getOHVFATMaskMultiLink,getOHVFATMaskMultiLink_overloads())
     .def("sbitReadOut",&xhal::rpc::AMC::sbitReadOut);
 
-  class_<xhal::rpc::CalRoutines, bases<xhal::XHALInterface> >("CalRoutines", init<const std::string&>())
+  //class_<xhal::rpc::CalRoutines, bases<xhal::XHALInterface> >("CalRoutines", init<const std::string&>())
+  class_<xhal::rpc::CalRoutines>("CalRoutines", init<const std::string&>())
+    .def("connect",&xhal::rpc::CalRoutines::connect)
+    .def("loadModule",&xhal::rpc::CalRoutines::loadModule)
+    .def("setLogLevel",&xhal::rpc::CalRoutines::setLogLevel)
     .def("checkSbitMappingWithCalPulse",&xhal::rpc::CalRoutines::checkSbitMappingWithCalPulse)
     .def("checkSbitRateWithCalPulse",&xhal::rpc::CalRoutines::checkSbitRateWithCalPulse)
     .def("genScan",&xhal::rpc::CalRoutines::genScan)
@@ -127,7 +135,11 @@ BOOST_PYTHON_MODULE(xhalpy){
     .def("ttcGenConf",&xhal::rpc::CalRoutines::ttcGenConf)
     .def("ttcGenToggle",&xhal::rpc::CalRoutines::ttcGenToggle);
 
-  class_<xhal::rpc::DaqMonitor, bases<xhal::XHALInterface> >("DaqMonitor", init<const std::string&>())
+  //class_<xhal::rpc::DaqMonitor, bases<xhal::XHALInterface> >("DaqMonitor", init<const std::string&>())
+  class_<xhal::rpc::DaqMonitor>("DaqMonitor", init<const std::string&>())
+    .def("connect",&xhal::rpc::DaqMonitor::connect)
+    .def("loadModule",&xhal::rpc::DaqMonitor::loadModule)
+    .def("setLogLevel",&xhal::rpc::DaqMonitor::setLogLevel)
     .def("getmonTTCmain",&xhal::rpc::DaqMonitor::getmonTTCmain)
     .def("getmonTRIGGERmain",&xhal::rpc::DaqMonitor::getmonTRIGGERmain,getmonTRIGGERmain_overloads())
     .def("getmonTRIGGEROHmain",&xhal::rpc::DaqMonitor::getmonTRIGGEROHmain,getmonTRIGGEROHmain_overloads())
@@ -180,7 +192,11 @@ BOOST_PYTHON_MODULE(xhalpy){
     .def("getUltraScanResults",&xhal::rpc::Optohybrid::getUltraScanResults)
     .def("stopCalPulse2AllChannels",&xhal::rpc::Optohybrid::stopCalPulse2AllChannels);
 
-  class_<xhal::rpc::Utils, bases<xhal::XHALInterface> >("Utils", init<const std::string&>())
+  //class_<xhal::rpc::Utils, bases<xhal::XHALInterface> >("Utils", init<const std::string&>())
+  class_<xhal::rpc::Utils>("Utils", init<const std::string&>())
+    .def("connect",&xhal::rpc::Utils::connect)
+    .def("loadModule",&xhal::rpc::Utils::loadModule)
+    .def("setLogLevel",&xhal::rpc::Utils::setLogLevel)
     .def("update_atdb",&xhal::rpc::Utils::update_atdb)
     .def("getRegInfoDB",&xhal::rpc::Utils::getRegInfoDB);
 

--- a/xhalcore/src/common/python_wrappers/XHALInterface_python.cpp
+++ b/xhalcore/src/common/python_wrappers/XHALInterface_python.cpp
@@ -1,6 +1,7 @@
 #include <boost/python.hpp>
 #include "xhal/utils/Exception.h"
 #include "xhal/XHALDevice.h"
+#include "xhal/utils/CalParamTypes.h"
 #include "xhal/utils/PyTypes.h"
 #include "xhal/rpc/amc.h"
 #include "xhal/rpc/calibration_routines.h"
@@ -50,6 +51,12 @@ PY_EXCEPTION_TRANSLATOR(translate_XHALRPCNotConnectedException,xhal::utils::XHAL
 uint32_t (xhal::XHALDevice::*readReg_byname)(std::string regName) = &xhal::XHALDevice::readReg;
 uint32_t (xhal::XHALDevice::*readReg_byaddress)(uint32_t address) = &xhal::XHALDevice::readReg;
 
+//AMC
+BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(getOHVFATMaskMultiLink_overloads, getOHVFATMaskMultiLink, 0, 1)
+
+//CalRoutines
+BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(sbitRateScan_overloads, sbitRateScan, 1, 3)
+
 //DaqMonitor
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(getmonTRIGGERmain_overloads, getmonTRIGGERmain, 0, 1)
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(getmonTRIGGEROHmain_overloads, getmonTRIGGEROHmain, 0, 1)
@@ -58,8 +65,8 @@ BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(getmonOHmain_overloads, getmonOHmain, 0, 
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(getmonOHSCAmain_overloads, getmonOHSCAmain, 0, 2)
 
 //VFAT3
-BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(readVFAT3ADC_overloads, readVFAT3ADC, 2, 4)
-BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(readVFAT3ADCMultiLink_overloads, readVFAT3ADCMultiLink, 3, 4)
+BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(readVFAT3ADC_overloads, readVFAT3ADC, 1, 3)
+BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(readVFAT3ADCMultiLink_overloads, readVFAT3ADCMultiLink, 2, 3)
 
 BOOST_PYTHON_MODULE(xhalpy){
   using namespace boost::python;
@@ -104,7 +111,7 @@ BOOST_PYTHON_MODULE(xhalpy){
 
   class_<xhal::rpc::AMC>("AMC", init<const std::string&, const std::string&>())
     .def("getOHVFATMask",&xhal::rpc::AMC::getOHVFATMask)
-    .def("getOHVFATMaskMultiLink",&xhal::rpc::AMC::getOHVFATMaskMultiLink)
+    .def("getOHVFATMaskMultiLink",&xhal::rpc::AMC::getOHVFATMaskMultiLink,getOHVFATMaskMultiLink_overloads())
     .def("sbitReadOut",&xhal::rpc::AMC::sbitReadOut);
 
   class_<xhal::rpc::CalRoutines>("CalRoutines", init<const std::string&>())
@@ -112,7 +119,7 @@ BOOST_PYTHON_MODULE(xhalpy){
     .def("checkSbitRateWithCalPulse",&xhal::rpc::CalRoutines::checkSbitRateWithCalPulse)
     .def("genScan",&xhal::rpc::CalRoutines::genScan)
     .def("genChannelScan",&xhal::rpc::CalRoutines::genChannelScan)
-    .def("sbitRateScan",&xhal::rpc::CalRoutines::sbitRateScan)
+    .def("sbitRateScan",&xhal::rpc::CalRoutines::sbitRateScan,sbitRateScan_overloads())
     .def("ttcGenConf",&xhal::rpc::CalRoutines::ttcGenConf)
     .def("ttcGenToggle",&xhal::rpc::CalRoutines::ttcGenToggle);
 
@@ -124,6 +131,41 @@ BOOST_PYTHON_MODULE(xhalpy){
     .def("getmonOHmain",&xhal::rpc::DaqMonitor::getmonOHmain,getmonOHmain_overloads())
     .def("getmonDAQmain",&xhal::rpc::DaqMonitor::getmonDAQmain)
     .def("getmonOHSCAmain",&xhal::rpc::DaqMonitor::getmonOHSCAmain,getmonOHSCAmain_overloads());
+
+  class_<xhal::ParamCalPulse>("ParamCalPulse")
+    .def_readwrite("enable", &xhal::ParamCalPulse::enable)
+    .def_readwrite("isCurrent", &xhal::ParamCalPulse::isCurrent)
+    .def_readwrite("duration", &xhal::ParamCalPulse::duration)
+    .def_readwrite("extVoltStep", &xhal::ParamCalPulse::extVoltStep)
+    .def_readwrite("height", &xhal::ParamCalPulse::height)
+    .def_readwrite("phase", &xhal::ParamCalPulse::phase)
+    .def_readwrite("polarity", &xhal::ParamCalPulse::polarity)
+    .def_readwrite("scaleFactor", &xhal::ParamCalPulse::scaleFactor);
+
+  class_<xhal::ParamScan>("ParamScan")
+    .def_readwrite("ohN", &xhal::ParamScan::ohN)
+    .def_readwrite("ohMask", &xhal::ParamScan::ohMask)
+    .def_readwrite("vfatN", &xhal::ParamScan::vfatN)
+    .def_readwrite("vfatMask", &xhal::ParamScan::vfatMask)
+    .def_readwrite("chan", &xhal::ParamScan::chan)
+    .def_readwrite("useUltra", &xhal::ParamScan::useUltra)
+    .def_readwrite("useExtTrig", &xhal::ParamScan::useExtTrig)
+    .def_readwrite("dacMax", &xhal::ParamScan::dacMax)
+    .def_readwrite("dacMin", &xhal::ParamScan::dacMin)
+    .def_readwrite("dacSelect", &xhal::ParamScan::dacSelect)
+    .def_readwrite("dacStep", &xhal::ParamScan::dacStep)
+    .def_readwrite("nevts", &xhal::ParamScan::nevts)
+    .def_readwrite("waitTime", &xhal::ParamScan::waitTime)
+    .def_readwrite("scanReg", &xhal::ParamScan::scanReg);
+
+  class_<xhal::ParamTtcGen>("ParamTtcGen")
+    .def_readwrite("enable", &xhal::ParamTtcGen::enable)
+    .def_readwrite("L1Ainterval", &xhal::ParamTtcGen::L1Ainterval)
+    .def_readwrite("mode", &xhal::ParamTtcGen::mode)
+    .def_readwrite("nPulses", &xhal::ParamTtcGen::nPulses)
+    .def_readwrite("pulseDelay", &xhal::ParamTtcGen::pulseDelay)
+    .def_readwrite("pulseRate", &xhal::ParamTtcGen::pulseRate)
+    .def_readwrite("type", &xhal::ParamTtcGen::type);
 
   class_<xhal::rpc::Optohybrid>("Optohybrid", init<const std::string&, const std::string&>())
     .def("broadcastRead",&xhal::rpc::Optohybrid::broadcastRead)

--- a/xhalcore/src/common/python_wrappers/XHALInterface_python.cpp
+++ b/xhalcore/src/common/python_wrappers/XHALInterface_python.cpp
@@ -2,7 +2,12 @@
 #include "xhal/utils/Exception.h"
 #include "xhal/XHALDevice.h"
 #include "xhal/utils/PyTypes.h"
+#include "xhal/rpc/amc.h"
+#include "xhal/rpc/calibration_routines.h"
 #include "xhal/rpc/daq_monitor.h"
+#include "xhal/rpc/optohybrid.h"
+#include "xhal/rpc/utils.h"
+#include "xhal/rpc/vfat3.h"
 #include <boost/python/suite/indexing/vector_indexing_suite.hpp>
 #include <boost/python/suite/indexing/map_indexing_suite.hpp>
 
@@ -45,11 +50,16 @@ PY_EXCEPTION_TRANSLATOR(translate_XHALRPCNotConnectedException,xhal::utils::XHAL
 uint32_t (xhal::XHALDevice::*readReg_byname)(std::string regName) = &xhal::XHALDevice::readReg;
 uint32_t (xhal::XHALDevice::*readReg_byaddress)(uint32_t address) = &xhal::XHALDevice::readReg;
 
+//DaqMonitor
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(getmonTRIGGERmain_overloads, getmonTRIGGERmain, 0, 1)
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(getmonTRIGGEROHmain_overloads, getmonTRIGGEROHmain, 0, 1)
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(getmonDAQOHmain_overloads, getmonDAQOHmain, 0, 1)
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(getmonOHmain_overloads, getmonOHmain, 0, 1)
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(getmonOHSCAmain_overloads, getmonOHSCAmain, 0, 2)
+
+//VFAT3
+BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(readVFAT3ADC_overloads, readVFAT3ADC, 2, 4)
+BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(readVFAT3ADCMultiLink_overloads, readVFAT3ADCMultiLink, 3, 4)
 
 BOOST_PYTHON_MODULE(xhalpy){
   using namespace boost::python;
@@ -92,6 +102,20 @@ BOOST_PYTHON_MODULE(xhalpy){
   class_<NestedPyDict<int,PyDictUint32<std::string> > >("NestedPyDict")
     .def(map_indexing_suite<NestedPyDict<int,PyDictUint32<std::string> > >() );
 
+  class_<xhal::rpc::AMC>("AMC", init<const std::string&, const std::string&>())
+    .def("getOHVFATMask",&xhal::rpc::AMC::getOHVFATMask)
+    .def("getOHVFATMaskMultiLink",&xhal::rpc::AMC::getOHVFATMaskMultiLink)
+    .def("sbitReadOut",&xhal::rpc::AMC::sbitReadOut);
+
+  class_<xhal::rpc::CalRoutines>("CalRoutines", init<const std::string&>())
+    .def("checkSbitMappingWithCalPulse",&xhal::rpc::CalRoutines::checkSbitMappingWithCalPulse)
+    .def("checkSbitRateWithCalPulse",&xhal::rpc::CalRoutines::checkSbitRateWithCalPulse)
+    .def("genScan",&xhal::rpc::CalRoutines::genScan)
+    .def("genChannelScan",&xhal::rpc::CalRoutines::genChannelScan)
+    .def("sbitRateScan",&xhal::rpc::CalRoutines::sbitRateScan)
+    .def("ttcGenConf",&xhal::rpc::CalRoutines::ttcGenConf)
+    .def("ttcGenToggle",&xhal::rpc::CalRoutines::ttcGenToggle);
+
   class_<xhal::rpc::DaqMonitor>("DaqMonitor", init<const std::string&>())
     .def("getmonTTCmain",&xhal::rpc::DaqMonitor::getmonTTCmain)
     .def("getmonTRIGGERmain",&xhal::rpc::DaqMonitor::getmonTRIGGERmain,getmonTRIGGERmain_overloads())
@@ -100,6 +124,29 @@ BOOST_PYTHON_MODULE(xhalpy){
     .def("getmonOHmain",&xhal::rpc::DaqMonitor::getmonOHmain,getmonOHmain_overloads())
     .def("getmonDAQmain",&xhal::rpc::DaqMonitor::getmonDAQmain)
     .def("getmonOHSCAmain",&xhal::rpc::DaqMonitor::getmonOHSCAmain,getmonOHSCAmain_overloads());
+
+  class_<xhal::rpc::Optohybrid>("Optohybrid", init<const std::string&, const std::string&>())
+    .def("broadcastRead",&xhal::rpc::Optohybrid::broadcastRead)
+    .def("broadcastWrite",&xhal::rpc::Optohybrid::broadcastWrite)
+    .def("configureScanModule",&xhal::rpc::Optohybrid::configureScanModule)
+    .def("printScanConfiguration",&xhal::rpc::Optohybrid::printScanConfiguration)
+    .def("startScanModule",&xhal::rpc::Optohybrid::startScanModule)
+    .def("getUltraScanResults",&xhal::rpc::Optohybrid::getUltraScanResults)
+    .def("stopCalPulse2AllChannels",&xhal::rpc::Optohybrid::stopCalPulse2AllChannels);
+
+  class_<xhal::rpc::Utils>("Utils", init<const std::string&>())
+    .def("update_atdb",&xhal::rpc::Utils::update_atdb)
+    .def("getRegInfoDB",&xhal::rpc::Utils::getRegInfoDB);
+
+  class_<xhal::rpc::VFAT3>("VFAT3", init<const std::string&, const std::string&>())
+    .def("configureVFAT3s",&xhal::rpc::VFAT3::configureVFAT3s)
+    .def("configureVFAT3DacMonitor",&xhal::rpc::VFAT3::configureVFAT3DacMonitor)
+    .def("configureVFAT3DacMonitorMultiLink",&xhal::rpc::VFAT3::configureVFAT3DacMonitorMultiLink)
+    .def("getChannelRegistersVFAT3",&xhal::rpc::VFAT3::getChannelRegistersVFAT3)
+    .def("readVFAT3ADC",&xhal::rpc::VFAT3::readVFAT3ADC,readVFAT3ADC_overloads())
+    .def("readVFAT3ADCMultiLink",&xhal::rpc::VFAT3::readVFAT3ADCMultiLink,readVFAT3ADCMultiLink_overloads())
+    .def("setChannelRegistersVFAT3",&xhal::rpc::VFAT3::setChannelRegistersVFAT3)
+    .def("setChannelRegistersVFAT3Simple",&xhal::rpc::VFAT3::setChannelRegistersVFAT3Simple);
 }
 
 // Converts a C++ map to a python dict

--- a/xhalcore/src/common/python_wrappers/XHALInterface_python.cpp
+++ b/xhalcore/src/common/python_wrappers/XHALInterface_python.cpp
@@ -49,6 +49,7 @@ BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(getmonTRIGGERmain_overloads, getmonTRIGGE
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(getmonTRIGGEROHmain_overloads, getmonTRIGGEROHmain, 0, 1)
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(getmonDAQOHmain_overloads, getmonDAQOHmain, 0, 1)
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(getmonOHmain_overloads, getmonOHmain, 0, 1)
+BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(getmonOHSCAmain_overloads, getmonOHSCAmain, 0, 2)
 
 BOOST_PYTHON_MODULE(xhalpy){
   using namespace boost::python;
@@ -88,13 +89,17 @@ BOOST_PYTHON_MODULE(xhalpy){
   class_<PyDictVecUint32<int> >("PyDictVecUint32")
     .def(map_indexing_suite<PyDictVecUint32<int> >() );
 
+  class_<NestedPyDict<int,PyDictUint32<std::string> > >("NestedPyDict")
+    .def(map_indexing_suite<NestedPyDict<int,PyDictUint32<std::string> > >() );
+
   class_<xhal::rpc::DaqMonitor>("DaqMonitor", init<const std::string&>())
     .def("getmonTTCmain",&xhal::rpc::DaqMonitor::getmonTTCmain)
     .def("getmonTRIGGERmain",&xhal::rpc::DaqMonitor::getmonTRIGGERmain,getmonTRIGGERmain_overloads())
     .def("getmonTRIGGEROHmain",&xhal::rpc::DaqMonitor::getmonTRIGGEROHmain,getmonTRIGGEROHmain_overloads())
     .def("getmonDAQOHmain",&xhal::rpc::DaqMonitor::getmonDAQOHmain,getmonDAQOHmain_overloads())
     .def("getmonOHmain",&xhal::rpc::DaqMonitor::getmonOHmain,getmonOHmain_overloads())
-    .def("getmonDAQmain",&xhal::rpc::DaqMonitor::getmonDAQmain);
+    .def("getmonDAQmain",&xhal::rpc::DaqMonitor::getmonDAQmain)
+    .def("getmonOHSCAmain",&xhal::rpc::DaqMonitor::getmonOHSCAmain,getmonOHSCAmain_overloads());
 }
 
 // Converts a C++ map to a python dict

--- a/xhalcore/src/common/python_wrappers/XHALInterface_python.cpp
+++ b/xhalcore/src/common/python_wrappers/XHALInterface_python.cpp
@@ -86,10 +86,10 @@ BOOST_PYTHON_MODULE(xhalpy){
     .def("loadModule",&xhal::XHALInterface::loadModule)
     .def("setLogLevel",&xhal::XHALInterface::setLogLevel);*/
 
-  class_<xhal::XHALDevice, bases<xhal::XHALInterface> >("XHALDevice", init<const std::string&, const std::string&>())
   class_<xhal::XHALDevice>("XHALDevice", init<const std::string&, const std::string&>())
     .def("connect",&xhal::XHALDevice::connect)
     .def("disconnect",&xhal::XHALDevice::disconnect)
+    .def("getBoardName",&xhal::XHALDevice::getBoardName)
     .def("getBlock",&xhal::XHALDevice::getBlock)
     .def("getList",&xhal::XHALDevice::getList)
     .def("loadModule",&xhal::XHALDevice::loadModule)
@@ -124,29 +124,31 @@ BOOST_PYTHON_MODULE(xhalpy){
 
   //class_<xhal::rpc::CalRoutines, bases<xhal::XHALInterface> >("CalRoutines", init<const std::string&>())
   class_<xhal::rpc::CalRoutines>("CalRoutines", init<const std::string&>())
-    .def("connect",&xhal::rpc::CalRoutines::connect)
-    .def("loadModule",&xhal::rpc::CalRoutines::loadModule)
-    .def("setLogLevel",&xhal::rpc::CalRoutines::setLogLevel)
     .def("checkSbitMappingWithCalPulse",&xhal::rpc::CalRoutines::checkSbitMappingWithCalPulse)
     .def("checkSbitRateWithCalPulse",&xhal::rpc::CalRoutines::checkSbitRateWithCalPulse)
+    .def("connect",&xhal::rpc::CalRoutines::connect)
     .def("genScan",&xhal::rpc::CalRoutines::genScan)
     .def("genChannelScan",&xhal::rpc::CalRoutines::genChannelScan)
+    .def("getBoardName",&xhal::rpc::CalRoutines::getBoardName)
+    .def("loadModule",&xhal::rpc::CalRoutines::loadModule)
     .def("sbitRateScan",&xhal::rpc::CalRoutines::sbitRateScan,sbitRateScan_overloads())
+    .def("setLogLevel",&xhal::rpc::CalRoutines::setLogLevel)
     .def("ttcGenConf",&xhal::rpc::CalRoutines::ttcGenConf)
     .def("ttcGenToggle",&xhal::rpc::CalRoutines::ttcGenToggle);
 
   //class_<xhal::rpc::DaqMonitor, bases<xhal::XHALInterface> >("DaqMonitor", init<const std::string&>())
   class_<xhal::rpc::DaqMonitor>("DaqMonitor", init<const std::string&>())
     .def("connect",&xhal::rpc::DaqMonitor::connect)
-    .def("loadModule",&xhal::rpc::DaqMonitor::loadModule)
-    .def("setLogLevel",&xhal::rpc::DaqMonitor::setLogLevel)
+    .def("getBoardName",&xhal::rpc::DaqMonitor::getBoardName)
     .def("getmonTTCmain",&xhal::rpc::DaqMonitor::getmonTTCmain)
     .def("getmonTRIGGERmain",&xhal::rpc::DaqMonitor::getmonTRIGGERmain,getmonTRIGGERmain_overloads())
     .def("getmonTRIGGEROHmain",&xhal::rpc::DaqMonitor::getmonTRIGGEROHmain,getmonTRIGGEROHmain_overloads())
     .def("getmonDAQOHmain",&xhal::rpc::DaqMonitor::getmonDAQOHmain,getmonDAQOHmain_overloads())
     .def("getmonOHmain",&xhal::rpc::DaqMonitor::getmonOHmain,getmonOHmain_overloads())
     .def("getmonDAQmain",&xhal::rpc::DaqMonitor::getmonDAQmain)
-    .def("getmonOHSCAmain",&xhal::rpc::DaqMonitor::getmonOHSCAmain,getmonOHSCAmain_overloads());
+    .def("getmonOHSCAmain",&xhal::rpc::DaqMonitor::getmonOHSCAmain,getmonOHSCAmain_overloads())
+    .def("loadModule",&xhal::rpc::DaqMonitor::loadModule)
+    .def("setLogLevel",&xhal::rpc::DaqMonitor::setLogLevel);
 
   class_<xhal::ParamCalPulse>("ParamCalPulse")
     .def_readwrite("enable", &xhal::ParamCalPulse::enable)
@@ -181,7 +183,8 @@ BOOST_PYTHON_MODULE(xhalpy){
     .def_readwrite("nPulses", &xhal::ParamTtcGen::nPulses)
     .def_readwrite("pulseDelay", &xhal::ParamTtcGen::pulseDelay)
     .def_readwrite("pulseRate", &xhal::ParamTtcGen::pulseRate)
-    .def_readwrite("type", &xhal::ParamTtcGen::type);
+    .def_readwrite("type", &xhal::ParamTtcGen::type)
+    .def("calcRate",&xhal::ParamTtcGen::calcRate);
 
   class_<xhal::rpc::Optohybrid, bases<xhal::XHALDevice> >("Optohybrid", init<const std::string&, const std::string&>())
     .def("broadcastRead",&xhal::rpc::Optohybrid::broadcastRead)

--- a/xhalcore/src/common/python_wrappers/XHALInterface_python.cpp
+++ b/xhalcore/src/common/python_wrappers/XHALInterface_python.cpp
@@ -72,12 +72,21 @@ BOOST_PYTHON_MODULE(xhalpy){
     .def("readReg",readReg_byname)
     .def("readReg",readReg_byaddress)
     .def("writeReg",&xhal::XHALDevice::writeReg);
-  
+
   class_<PyListUint32>("PyListUint32")
     .def(vector_indexing_suite<PyListUint32>() );
 
-  class_<PyDictVecUint32>("PyDictVecUint32")
-    .def(map_indexing_suite<PyDictVecUint32>() );
+  class_<PyDictUint32<std::string> >("PyDictUint32")
+    .def(map_indexing_suite<PyDictUint32<std::string> >() );
+
+  class_<PyDictUint32<int> >("PyDictUint32")
+    .def(map_indexing_suite<PyDictUint32<int> >() );
+
+  class_<PyDictVecUint32<std::string> >("PyDictVecUint32")
+    .def(map_indexing_suite<PyDictVecUint32<std::string> >() );
+
+  class_<PyDictVecUint32<int> >("PyDictVecUint32")
+    .def(map_indexing_suite<PyDictVecUint32<int> >() );
 
   class_<xhal::rpc::DaqMonitor>("DaqMonitor", init<const std::string&>())
     .def("getmonTTCmain",&xhal::rpc::DaqMonitor::getmonTTCmain)
@@ -86,4 +95,16 @@ BOOST_PYTHON_MODULE(xhalpy){
     .def("getmonDAQOHmain",&xhal::rpc::DaqMonitor::getmonDAQOHmain,getmonDAQOHmain_overloads())
     .def("getmonOHmain",&xhal::rpc::DaqMonitor::getmonOHmain,getmonOHmain_overloads())
     .def("getmonDAQmain",&xhal::rpc::DaqMonitor::getmonDAQmain);
+}
+
+// Converts a C++ map to a python dict
+template <class K, class V>
+boost::python::dict convert2dict(const std::map<K,V> inputMap){
+    typename std::map<K,V>::const_iterator iter;
+    boost::python::dict ret_dict;
+    for(iter = inputMap.begin(); iter != inputMap.end(); ++iter){
+        ret_dict[(*iter).first] = (*iter).second;
+    }
+
+    return ret_dict;
 }

--- a/xhalcore/src/common/rpc_manager/amc.cc
+++ b/xhalcore/src/common/rpc_manager/amc.cc
@@ -4,6 +4,53 @@
 #include <vector>
 #include "xhal/rpc/amc.h"
 
+DLLEXPORT uint32_t getOHVFATMask(uint32_t ohN){
+    req = wisc::RPCMsg("amc.getOHVFATMask");
+
+    req.set_word("ohN",ohN);
+
+    wisc::RPCSvc* rpc_loc = getRPCptr();
+    try {
+        rsp = rpc_loc->call_method(req);
+    }
+    STANDARD_CATCH;
+
+    if (rsp.get_key_exists("error")) {
+        printf("Caught an error: %s\n", (rsp.get_string("error")).c_str());
+        return 0xffffffff;
+    }
+
+    return rsp.get_word("vfatMask");
+} //End getOHVFATMask(...)
+
+DLLEXPORT uint32_t getOHVFATMaskMultiLink(uint32_t ohMask, uint32_t * ohVfatMaskArray){
+    req = wisc::RPCMsg("amc.getOHVFATMaskMultiLink");
+
+    req.set_word("ohMask", ohMask);
+
+    wisc::RPCSvc* rpc_loc = getRPCptr();
+
+    try {
+        rsp = rpc_loc->call_method(req);
+    }
+    STANDARD_CATCH;
+
+    if (rsp.get_key_exists("error")) {
+        printf("Caught an error: %s\n", (rsp.get_string("error")).c_str());
+        return 1;
+    }
+    const uint32_t size = 12;
+    if (rsp.get_key_exists("ohVfatMaskArray")) {
+        ASSERT(rsp.get_word_array_size("ohVfatMaskArray") == size);
+        rsp.get_word_array("ohVfatMaskArray", ohVfatMaskArray);
+    } else {
+        printf("No ohVfatMaskArray key found");
+        return 1;
+    }
+
+    return 0;
+} //End getOHVFATMaskMultiLink(...)
+
 DLLEXPORT uint32_t sbitReadOut(uint32_t ohN, uint32_t acquireTime, char * outFilePath){
     req = wisc::RPCMsg("amc.sbitReadOut");
 

--- a/xhalcore/src/common/rpc_manager/amc.cc
+++ b/xhalcore/src/common/rpc_manager/amc.cc
@@ -4,14 +4,19 @@
 #include <vector>
 #include "xhal/rpc/amc.h"
 
-DLLEXPORT uint32_t getOHVFATMask(uint32_t ohN){
+xhal::rpc::AMC3::AMC3(const std::string& board_domain_name, const std::string& address_table_filename):
+  xhal::XHALDevice(board_domain_name, address_table_filename)
+{
+  this->loadModule("amc","amc v1.0.1");
+}
+
+uint32_t xhal::rpc::AMC::getOHVFATMask(uint32_t ohN){
     req = wisc::RPCMsg("amc.getOHVFATMask");
 
     req.set_word("ohN",ohN);
 
-    wisc::RPCSvc* rpc_loc = getRPCptr();
     try {
-        rsp = rpc_loc->call_method(req);
+        rsp = rpc.call_method(req);
     }
     STANDARD_CATCH;
 
@@ -23,15 +28,13 @@ DLLEXPORT uint32_t getOHVFATMask(uint32_t ohN){
     return rsp.get_word("vfatMask");
 } //End getOHVFATMask(...)
 
-DLLEXPORT uint32_t getOHVFATMaskMultiLink(uint32_t ohMask, uint32_t * ohVfatMaskArray){
+uint32_t xhal::rpc::AMC::getOHVFATMaskMultiLink(uint32_t ohMask, uint32_t * ohVfatMaskArray){
     req = wisc::RPCMsg("amc.getOHVFATMaskMultiLink");
 
     req.set_word("ohMask", ohMask);
 
-    wisc::RPCSvc* rpc_loc = getRPCptr();
-
     try {
-        rsp = rpc_loc->call_method(req);
+        rsp = rpc.call_method(req);
     }
     STANDARD_CATCH;
 
@@ -51,13 +54,11 @@ DLLEXPORT uint32_t getOHVFATMaskMultiLink(uint32_t ohMask, uint32_t * ohVfatMask
     return 0;
 } //End getOHVFATMaskMultiLink(...)
 
-DLLEXPORT uint32_t sbitReadOut(uint32_t ohN, uint32_t acquireTime, char * outFilePath){
+uint32_t xhal::rpc::AMC::sbitReadOut(uint32_t ohN, uint32_t acquireTime, char * outFilePath){
     req = wisc::RPCMsg("amc.sbitReadOut");
 
     req.set_word("ohN",ohN);
     req.set_word("acquireTime",acquireTime);
-
-    wisc::RPCSvc* rpc_loc = getRPCptr();
 
     uint32_t netTime = 0;
     int runNum = 1;
@@ -81,7 +82,7 @@ DLLEXPORT uint32_t sbitReadOut(uint32_t ohN, uint32_t acquireTime, char * outFil
 
         //Call RPC Method
         try {
-            rsp = rpc_loc->call_method(req);
+            rsp = rpc.call_method(req);
         }
         STANDARD_CATCH;
 

--- a/xhalcore/src/common/rpc_manager/amc.cc
+++ b/xhalcore/src/common/rpc_manager/amc.cc
@@ -18,7 +18,7 @@ DLLEXPORT uint32_t sbitReadOut(uint32_t ohN, uint32_t acquireTime, char * outFil
     //Acquire data
     printf("sbitReadOut(): Beginning acquisition of trigger data\n");
     while(netTime < acquireTime){ //Acquisition Loop
-        printf("sbitReadOut(): acquired data for %i seconds of requested %i seconds, data taking continues", netTime, acquireTime);
+        printf("sbitReadOut(): acquired data for %i seconds of requested %i seconds, data taking continues\n", netTime, acquireTime);
 
         //Open output file for this acquisition
         std::string strFileName(outFilePath);

--- a/xhalcore/src/common/rpc_manager/amc.cc
+++ b/xhalcore/src/common/rpc_manager/amc.cc
@@ -1,0 +1,99 @@
+#include "errno.h" //See: http://www.virtsync.com/c-error-codes-include-errno
+#include <fstream>
+#include <string>
+#include <vector>
+#include "xhal/rpc/amc.h"
+
+DLLEXPORT uint32_t sbitReadOut(uint32_t ohN, uint32_t acquireTime, char * outFilePath){
+    req = wisc::RPCMsg("amc.sbitReadOut");
+
+    req.set_word("ohN",ohN);
+    req.set_word("acquireTime",acquireTime);
+
+    wisc::RPCSvc* rpc_loc = getRPCptr();
+
+    uint32_t netTime = 0;
+    int runNum = 1;
+
+    //Acquire data
+    printf("sbitReadOut(): Beginning acquisition of trigger data\n");
+    while(netTime < acquireTime){ //Acquisition Loop
+        printf("sbitReadOut(): acquired data for %i seconds of requested %i seconds, data taking continues", netTime, acquireTime);
+
+        //Open output file for this acquisition
+        std::string strFileName(outFilePath);
+        strFileName = strFileName+"/sbitReadOut_run"+std::to_string(runNum)+".dat";
+        std::fstream fileTrigData;
+        fileTrigData.open(strFileName, std::ios::out);
+        if (!fileTrigData.is_open()){
+            printf("sbitReadOut(): Error while trying to open file %s\n",outFilePath);
+            printf("sbitReadOut(): Perhaps you do not have write permissions or the filepath does not exist?\n");
+            printf("sbitReadOut(): Exiting\n");
+            return EIO;
+        }
+
+        //Call RPC Method
+        try {
+            rsp = rpc_loc->call_method(req);
+        }
+        STANDARD_CATCH;
+
+        //Check for RPC Error
+        if (rsp.get_key_exists("error")) {
+            printf("sbitReadOut(): Caught an error: %s\n", (rsp.get_string("error")).c_str());
+            fileTrigData.close();
+            return 1;
+        }
+
+        //If max network size reached before acquireTime was reached
+        //increment netTime and we will take more data in the next loop
+        if(rsp.get_key_exists("maxNetworkSizeReached")){
+            netTime += rsp.get_word("approxLiveTime");
+        }
+        else{
+            netTime += acquireTime;
+        }
+
+        //Write data to file
+        std::vector<uint32_t> vec_sbitData;
+        if (rsp.get_key_exists("storedSbits")) {
+            vec_sbitData = rsp.get_word_array("storedSbits");
+        } else {
+            printf("sbitReadOut(): No sbit data found");
+            return 1;
+        }
+
+        fileTrigData<<"evtNum/i:";
+        for(int cluster=0; cluster < 8; ++cluster){
+            fileTrigData<<"sbitClusterData" << cluster << "/i:";
+        }
+        fileTrigData<<std::endl;
+
+        uint32_t sbitPos = 1;
+        uint32_t evtNum = 0;
+        for(auto iterSBIT = vec_sbitData.begin(); iterSBIT != vec_sbitData.end(); ++iterSBIT){ //Loop over stored sbits
+            if(iterSBIT == vec_sbitData.begin()){
+                fileTrigData << evtNum << "\t" << (*iterSBIT) << "\t";
+                evtNum++;
+            }
+            else{
+                if( 0 == (sbitPos % 8)){ //Last cluster of current event
+                    fileTrigData << (*iterSBIT) << "\n";
+                }
+                else if( 1 == (sbitPos % 8)){ //New Event
+                    fileTrigData << evtNum << "\t" << (*iterSBIT) << "\t";
+                    evtNum++;
+                }
+                else{ //2nd through 7th cluster of current evet
+                    fileTrigData << (*iterSBIT) << "\t";
+                }
+            }
+            sbitPos++;
+        } //End loop over stored sbits
+        fileTrigData.close();
+
+        runNum++;
+    } //End Acquisition Loop
+
+    return 0;
+} //End sbitReadOut(...)

--- a/xhalcore/src/common/rpc_manager/amc.cpp
+++ b/xhalcore/src/common/rpc_manager/amc.cpp
@@ -4,7 +4,7 @@
 #include <vector>
 #include "xhal/rpc/amc.h"
 
-xhal::rpc::AMC3::AMC3(const std::string& board_domain_name, const std::string& address_table_filename):
+xhal::rpc::AMC::AMC(const std::string& board_domain_name, const std::string& address_table_filename):
   xhal::XHALDevice(board_domain_name, address_table_filename)
 {
   this->loadModule("amc","amc v1.0.1");

--- a/xhalcore/src/common/rpc_manager/amc.cpp
+++ b/xhalcore/src/common/rpc_manager/amc.cpp
@@ -22,10 +22,10 @@ uint32_t xhal::rpc::AMC::getOHVFATMask(uint32_t ohN){
     STANDARD_CATCH;
 
     if (rsp.get_key_exists("error")) {
-        throw xhal::utils::Exception(strcat("RPC exception: ", rsp.get_string("error").c_str()));
+        throw xhal::utils::XHALRPCException(strcat("RPC exception: ", rsp.get_string("error").c_str()));
     }
     else if (!rsp.get_key_exists("vfatMask")) {
-        throw xhal::utils::Exception("RPC exception: no VFAT Mask data found");
+        throw xhal::utils::XHALRPCException("RPC exception: no VFAT Mask data found");
     }
 
     return rsp.get_word("vfatMask");
@@ -42,10 +42,10 @@ PyListUint32 xhal::rpc::AMC::getOHVFATMaskMultiLink(uint32_t ohMask){
     STANDARD_CATCH;
 
     if (rsp.get_key_exists("error")) {
-        throw xhal::utils::Exception(strcat("RPC exception: ", rsp.get_string("error").c_str()));
+        throw xhal::utils::XHALRPCException(strcat("RPC exception: ", rsp.get_string("error").c_str()));
     }
     else if (!rsp.get_key_exists("ohVfatMaskArray")) {
-        throw xhal::utils::Exception("RPC exception: no OH VFAT Mask data found");
+        throw xhal::utils::XHALRPCException("RPC exception: no OH VFAT Mask data found");
     }
 
     return rsp.get_word_array("ohVfatMaskArray");
@@ -85,7 +85,7 @@ void xhal::rpc::AMC::sbitReadOut(uint32_t ohN, uint32_t acquireTime, std::string
         //Check for RPC Error
         if (rsp.get_key_exists("error")) {
             fileTrigData.close();
-            throw xhal::utils::Exception(strcat("RPC exception: ", rsp.get_string("error").c_str()));
+            throw xhal::utils::XHALRPCException(strcat("RPC exception: ", rsp.get_string("error").c_str()));
         }
 
         //If max network size reached before acquireTime was reached
@@ -102,7 +102,7 @@ void xhal::rpc::AMC::sbitReadOut(uint32_t ohN, uint32_t acquireTime, std::string
         if (rsp.get_key_exists("storedSbits")) {
             vec_sbitData = rsp.get_word_array("storedSbits");
         } else {
-            throw xhal::utils::Exception("RPC exception: no storedSbits found");
+            throw xhal::utils::XHALRPCException("RPC exception: no storedSbits found");
         }
 
         fileTrigData<<"evtNum/i:";

--- a/xhalcore/src/common/rpc_manager/amc.cpp
+++ b/xhalcore/src/common/rpc_manager/amc.cpp
@@ -7,6 +7,7 @@
 xhal::rpc::AMC::AMC(const std::string& board_domain_name, const std::string& address_table_filename):
   xhal::XHALDevice(board_domain_name, address_table_filename)
 {
+  m_map_modName_modVer["amc"]="amc v1.0.1";
   this->loadModule("amc","amc v1.0.1");
 }
 

--- a/xhalcore/src/common/rpc_manager/calibration_routines.cpp
+++ b/xhalcore/src/common/rpc_manager/calibration_routines.cpp
@@ -23,7 +23,7 @@ PyListUint32 xhal::rpc::CalRoutines::checkSbitMappingWithCalPulse(xhal::ParamSca
     STANDARD_CATCH;
 
     if (rsp.get_key_exists("error")) {
-        throw xhal::utils::Exception(strcat("RPC exception: ", rsp.get_string("error").c_str()));
+        throw xhal::utils::XHALRPCException(strcat("RPC exception: ", rsp.get_string("error").c_str()));
     }
 
     PyListUint32 data;
@@ -31,7 +31,7 @@ PyListUint32 xhal::rpc::CalRoutines::checkSbitMappingWithCalPulse(xhal::ParamSca
         data = rsp.get_word_array("data");
     }
     else{
-        throw xhal::utils::Exception("RPC exception: no SBIT mapping data found");
+        throw xhal::utils::XHALRPCException("RPC exception: no SBIT mapping data found");
     }
 
     return data;
@@ -59,7 +59,7 @@ PyDictVecUint32<std::string> xhal::rpc::CalRoutines::checkSbitRateWithCalPulse(x
     STANDARD_CATCH;
 
     if (rsp.get_key_exists("error")) {
-        throw xhal::utils::Exception(strcat("RPC exception: ", rsp.get_string("error").c_str()));
+        throw xhal::utils::XHALRPCException(strcat("RPC exception: ", rsp.get_string("error").c_str()));
     }
 
     PyDictVecUint32<std::string> ret_dictRateData;
@@ -67,21 +67,21 @@ PyDictVecUint32<std::string> xhal::rpc::CalRoutines::checkSbitRateWithCalPulse(x
         ret_dictRateData["CTP7"]=rsp.get_word_array("outDataCTP7Rate");
     }
     else{
-        throw xhal::utils::Exception("RPC exception: no SBIT rate data from CTP7 found");
+        throw xhal::utils::XHALRPCException("RPC exception: no SBIT rate data from CTP7 found");
     }
 
     if (rsp.get_key_exists("outDataFPGAClusterCntRate")) {
         ret_dictRateData["FPGA"]=rsp.get_word_array("outDataFPGARate");
     }
     else{
-        throw xhal::utils::Exception("RPC exception: no SBIT rate data from FPGA found");
+        throw xhal::utils::XHALRPCException("RPC exception: no SBIT rate data from FPGA found");
     }
 
     if (rsp.get_key_exists("outDataVFATSBits")) {
         ret_dictRateData["VFAT"]=rsp.get_word_array("outDataVFATRate");
     }
     else{
-        throw xhal::utils::Exception("RPC exception: no SBIT rate data from VFAT found");
+        throw xhal::utils::XHALRPCException("RPC exception: no SBIT rate data from VFAT found");
     }
 
     return ret_dictRateData;
@@ -114,14 +114,14 @@ PyListUint32 xhal::rpc::CalRoutines::genScan(xhal::ParamScan &scanParams, xhal::
     STANDARD_CATCH;
 
     if (rsp.get_key_exists("error")) {
-        throw xhal::utils::Exception(strcat("RPC exception: ", rsp.get_string("error").c_str()));
+        throw xhal::utils::XHALRPCException(strcat("RPC exception: ", rsp.get_string("error").c_str()));
     }
 
     PyListUint32 data;
     if (rsp.get_key_exists("data")) {
         data = rsp.get_word_array("data");
     } else {
-        throw xhal::utils::Exception("RPC exception: no data from generic scan found");
+        throw xhal::utils::XHALRPCException("RPC exception: no data from generic scan found");
     }
 
     return data;
@@ -158,14 +158,14 @@ PyListUint32 xhal::rpc::CalRoutines::genChannelScan(xhal::ParamScan &scanParams,
     STANDARD_CATCH;
 
     if (rsp.get_key_exists("error")) {
-        throw xhal::utils::Exception(strcat("RPC exception: ", rsp.get_string("error").c_str()));
+        throw xhal::utils::XHALRPCException(strcat("RPC exception: ", rsp.get_string("error").c_str()));
     }
 
     PyListUint32 data;
     if (rsp.get_key_exists("data")) {
         data = rsp.get_word_array("data");
     } else {
-        throw xhal::utils::Exception("RPC exception: no data from generic channel scan found");
+        throw xhal::utils::XHALRPCException("RPC exception: no data from generic channel scan found");
     }
 
     return data;
@@ -177,7 +177,7 @@ PyDictVecUint32<std::string> xhal::rpc::CalRoutines::sbitRateScan(xhal::ParamSca
 
 
     req.set_word("ohN",scanParams.ohN);
-    req.set_word("mask",scanParams.vfatMask);
+    req.set_word("maskOh",scanParams.vfatMask);
     req.set_word("dacMin",scanParams.dacMin);
     req.set_word("dacMax",scanParams.dacMax);
     req.set_word("dacStep",scanParams.dacStep);
@@ -200,19 +200,19 @@ PyDictVecUint32<std::string> xhal::rpc::CalRoutines::sbitRateScan(xhal::ParamSca
 
     PyDictVecUint32<std::string> ret_dictRateData;
     if (rsp.get_key_exists("error")) {
-        throw xhal::utils::Exception(strcat("RPC exception: ", rsp.get_string("error").c_str()));
+        throw xhal::utils::XHALRPCException(strcat("RPC exception: ", rsp.get_string("error").c_str()));
     }
 
     if (rsp.get_key_exists("outDataDacValue")) {
         ret_dictRateData["DACVAL"] = rsp.get_word_array("outDataDacValue");
     } else {
-        throw xhal::utils::Exception("RPC exception: no dac values from sbit rate scan found");
+        throw xhal::utils::XHALRPCException("RPC exception: no dac values from sbit rate scan found");
     }
 
     if (rsp.get_key_exists("outDataCTP7Rate")) {
         ret_dictRateData["CTP7Rate"] = rsp.get_word_array("outDataCTP7Rate");
     } else {
-        throw xhal::utils::Exception("RPC exception: no data for CTP7 rate from sbit rate scan found");
+        throw xhal::utils::XHALRPCException("RPC exception: no data for CTP7 rate from sbit rate scan found");
     }
 
     if(isParallel){
@@ -220,7 +220,7 @@ PyDictVecUint32<std::string> xhal::rpc::CalRoutines::sbitRateScan(xhal::ParamSca
             ret_dictRateData["VFATRate"] = rsp.get_word_array("outDataVFATRate");
         }
         else{
-            throw xhal::utils::Exception("RPC exception: no data for VFAT rate from sbit rate scan found");
+            throw xhal::utils::XHALRPCException("RPC exception: no data for VFAT rate from sbit rate scan found");
         }
     }
 
@@ -247,7 +247,7 @@ void xhal::rpc::CalRoutines::ttcGenConf(uint32_t ohN, xhal::ParamTtcGen &ttcGenP
     STANDARD_CATCH;
 
     if (rsp.get_key_exists("error")) {
-        throw xhal::utils::Exception(strcat("RPC exception: ", rsp.get_string("error").c_str()));
+        throw xhal::utils::XHALRPCException(strcat("RPC exception: ", rsp.get_string("error").c_str()));
     }
 
     return;
@@ -264,7 +264,7 @@ void xhal::rpc::CalRoutines::ttcGenToggle(uint32_t ohN, bool enable)
     STANDARD_CATCH;
 
     if (rsp.get_key_exists("error")) {
-        throw xhal::utils::Exception(strcat("RPC exception: ", rsp.get_string("error").c_str()));
+        throw xhal::utils::XHALRPCException(strcat("RPC exception: ", rsp.get_string("error").c_str()));
     }
 
     return;

--- a/xhalcore/src/common/rpc_manager/calibration_routines.cpp
+++ b/xhalcore/src/common/rpc_manager/calibration_routines.cpp
@@ -1,18 +1,21 @@
+#include <stdexcept>
 #include "xhal/rpc/calibration_routines.h"
 
-uint32_t xhal::rpc::CalRoutines::checkSbitMappingWithCalPulse(uint32_t ohN, uint32_t vfatN, uint32_t mask, bool useCalPulse, bool currentPulse, uint32_t calScaleFactor, uint32_t nevts, uint32_t L1Ainterval, uint32_t pulseDelay, uint32_t *data)
+PyListUint32 xhal::rpc::CalRoutines::checkSbitMappingWithCalPulse(xhal::ParamScan &scanParams, xhal::ParamCalPulse &calPulseParams, xhal::ParamTtcGen &ttcGenParams)
 {
     req = wisc::RPCMsg("calibration_routines.checkSbitMappingWithCalPulse");
 
-    req.set_word("ohN", ohN);
-    req.set_word("vfatN", vfatN);
-    req.set_word("mask", mask);
-    req.set_word("useCalPulse", useCalPulse);
-    req.set_word("currentPulse", currentPulse);
-    req.set_word("calScaleFactor", calScaleFactor);
-    req.set_word("nevts", nevts);
-    req.set_word("L1Ainterval", L1Ainterval);
-    req.set_word("pulseDelay", pulseDelay);
+    req.set_word("ohN", scanParams.ohN);
+    req.set_word("vfatN", scanParams.vfatN);
+    req.set_word("mask", scanParams.vfatMask);
+    req.set_word("nevts", scanParams.nevts);
+
+    req.set_word("useCalPulse", calPulseParams.enable);
+    req.set_word("currentPulse", calPulseParams.isCurrent);
+    req.set_word("calScaleFactor", calPulseParams.scaleFactor);
+
+    req.set_word("L1Ainterval", ttcGenParams.L1Ainterval);
+    req.set_word("pulseDelay", ttcGenParams.pulseDelay);
 
     try {
         rsp = rpc.call_method(req);
@@ -20,36 +23,35 @@ uint32_t xhal::rpc::CalRoutines::checkSbitMappingWithCalPulse(uint32_t ohN, uint
     STANDARD_CATCH;
 
     if (rsp.get_key_exists("error")) {
-        printf("Caught an error: %s\n", (rsp.get_string("error")).c_str());
-        return 1;
+        throw xhal::utils::Exception(strcat("RPC exception: ", rsp.get_string("error").c_str()));
     }
 
-    const uint32_t size = 128*8*nevts;
+    PyListUint32 data;
     if (rsp.get_key_exists("data")){
-        ASSERT(rsp.get_word_array_size("data") == size);
-        rsp.get_word_array("data",data);
+        data = rsp.get_word_array("data");
     }
     else{
-        printf("No key found for data");
-        return 1;
+        throw xhal::utils::Exception("RPC exception: no SBIT mapping data found");
     }
 
-    return 0;
+    return data;
 } //End checkSbitMappingWithCalPulse()
 
-uint32_t xhal::rpc::CalRoutines::checkSbitRateWithCalPulse(uint32_t ohN, uint32_t vfatN, uint32_t mask, bool useCalPulse, bool currentPulse, uint32_t calScaleFactor, uint32_t waitTime, uint32_t pulseRate, uint32_t pulseDelay, uint32_t *outDataCTP7Rate, uint32_t *outDataFPGAClusterCntRate, uint32_t *outDataVFATSBits)
+PyDictVecUint32<std::string> xhal::rpc::CalRoutines::checkSbitRateWithCalPulse(xhal::ParamScan &scanParams, xhal::ParamCalPulse &calPulseParams, xhal::ParamTtcGen &ttcGenParams)
 {
     req = wisc::RPCMsg("calibration_routines.checkSbitRateWithCalPulse");
 
-    req.set_word("ohN", ohN);
-    req.set_word("vfatN", vfatN);
-    req.set_word("mask", mask);
-    req.set_word("useCalPulse", useCalPulse);
-    req.set_word("currentPulse", currentPulse);
-    req.set_word("calScaleFactor", calScaleFactor);
-    req.set_word("waitTime", waitTime);
-    req.set_word("pulseRate", pulseRate);
-    req.set_word("pulseDelay", pulseDelay);
+    req.set_word("ohN", scanParams.ohN);
+    req.set_word("vfatN", scanParams.vfatN);
+    req.set_word("mask", scanParams.vfatMask);
+    req.set_word("waitTime", scanParams.waitTime);
+
+    req.set_word("useCalPulse", calPulseParams.enable);
+    req.set_word("currentPulse", calPulseParams.isCurrent);
+    req.set_word("calScaleFactor", calPulseParams.scaleFactor);
+
+    req.set_word("pulseRate", ttcGenParams.pulseRate);
+    req.set_word("pulseDelay", ttcGenParams.pulseDelay);
 
     try {
         rsp = rpc.call_method(req);
@@ -57,60 +59,54 @@ uint32_t xhal::rpc::CalRoutines::checkSbitRateWithCalPulse(uint32_t ohN, uint32_
     STANDARD_CATCH;
 
     if (rsp.get_key_exists("error")) {
-        printf("Caught an error: %s\n", (rsp.get_string("error")).c_str());
-        return 1;
+        throw xhal::utils::Exception(strcat("RPC exception: ", rsp.get_string("error").c_str()));
     }
 
-    const uint32_t size = 128;
+    PyDictVecUint32<std::string> ret_dictRateData;
     if (rsp.get_key_exists("outDataCTP7Rate")) {
-        ASSERT(rsp.get_word_array_size("outDataCTP7Rate") == size);
-        rsp.get_word_array("outDataCTP7Rate", outDataCTP7Rate);
+        ret_dictRateData["CTP7"]=rsp.get_word_array("outDataCTP7Rate");
     }
     else{
-        printf("No key found for outDataCTP7Rate");
-        return 1;
+        throw xhal::utils::Exception("RPC exception: no SBIT rate data from CTP7 found");
     }
 
     if (rsp.get_key_exists("outDataFPGAClusterCntRate")) {
-        ASSERT(rsp.get_word_array_size("outDataFPGAClusterCntRate") == size);
-        rsp.get_word_array("outDataFPGAClusterCntRate", outDataFPGAClusterCntRate);
+        ret_dictRateData["FPGA"]=rsp.get_word_array("outDataFPGARate");
     }
     else{
-        printf("No key found for outDataFPGAClusterCntRate");
-        return 1;
+        throw xhal::utils::Exception("RPC exception: no SBIT rate data from FPGA found");
     }
 
     if (rsp.get_key_exists("outDataVFATSBits")) {
-        ASSERT(rsp.get_word_array_size("outDataVFATSBits") == size);
-        rsp.get_word_array("outDataVFATSBits", outDataVFATSBits);
+        ret_dictRateData["VFAT"]=rsp.get_word_array("outDataVFATRate");
     }
     else{
-        printf("No key found for outDataVFATSBits");
-        return 1;
+        throw xhal::utils::Exception("RPC exception: no SBIT rate data from VFAT found");
     }
 
-    return 0;
+    return ret_dictRateData;
 } //End checkSbitRateWithCalPulse()
 
-uint32_t xhal::rpc::CalRoutines::genScan(uint32_t nevts, uint32_t ohN, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep, uint32_t ch, bool useCalPulse, bool currentPulse, uint32_t calScaleFactor, uint32_t mask, char * scanReg, bool useUltra, bool useExtTrig, uint32_t * result)
+PyListUint32 xhal::rpc::CalRoutines::genScan(xhal::ParamScan &scanParams, xhal::ParamCalPulse &calPulseParams)
 {
     req = wisc::RPCMsg("calibration_routines.genScan");
 
-    req.set_word("nevts", nevts);
-    req.set_word("ohN", ohN);
-    req.set_word("dacMin", dacMin);
-    req.set_word("dacMax", dacMax);
-    req.set_word("dacStep", dacStep);
-    req.set_word("ch", ch);
-    req.set_word("useCalPulse", useCalPulse);
-    req.set_word("currentPulse", currentPulse);
-    req.set_word("calScaleFactor", calScaleFactor);
-    req.set_word("mask", mask);
-    if(useUltra){
-        req.set_word("useUltra", useUltra);
+    req.set_word("nevts",scanParams.nevts);
+    req.set_word("ohN",scanParams.ohN);
+    req.set_word("dacMin",scanParams.dacMin);
+    req.set_word("dacMax",scanParams.dacMax);
+    req.set_word("dacStep",scanParams.dacStep);
+    req.set_word("ch",scanParams.chan);
+    req.set_word("mask",scanParams.vfatMask);
+    if(scanParams.useUltra){
+        req.set_word("useUltra",scanParams.useUltra);
     }
-    req.set_word("useExtTrig", useExtTrig);
-    req.set_string("scanReg", std::string(scanReg));
+    req.set_word("useExtTrig",scanParams.useExtTrig);
+    req.set_string("scanReg",scanParams.scanReg);
+
+    req.set_word("useCalPulse", calPulseParams.enable);
+    req.set_word("currentPulse", calPulseParams.isCurrent);
+    req.set_word("calScaleFactor", calPulseParams.scaleFactor);
 
     try {
         rsp = rpc.call_method(req);
@@ -118,39 +114,43 @@ uint32_t xhal::rpc::CalRoutines::genScan(uint32_t nevts, uint32_t ohN, uint32_t 
     STANDARD_CATCH;
 
     if (rsp.get_key_exists("error")) {
-        printf("Caught an error: %s\n", (rsp.get_string("error")).c_str());
-        return 1;
-    }
-    const uint32_t size = (dacMax - dacMin+1)*24/dacStep;
-    if (rsp.get_key_exists("data")) {
-        ASSERT(rsp.get_word_array_size("data") == size);
-        rsp.get_word_array("data", result);
-    } else {
-        printf("No data key found");
-        return 1;
+        throw xhal::utils::Exception(strcat("RPC exception: ", rsp.get_string("error").c_str()));
     }
 
-    return 0;
+    PyListUint32 data;
+    if (rsp.get_key_exists("data")) {
+        data = rsp.get_word_array("data");
+    } else {
+        throw xhal::utils::Exception("RPC exception: no data from generic scan found");
+    }
+
+    return data;
 }
 
-uint32_t xhal::rpc::CalRoutines::genChannelScan(uint32_t nevts, uint32_t ohN, uint32_t mask, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep, bool useCalPulse, bool currentPulse, uint32_t calScaleFactor, bool useExtTrig, char * scanReg, bool useUltra, uint32_t * result)
+PyListUint32 xhal::rpc::CalRoutines::genChannelScan(xhal::ParamScan &scanParams, xhal::ParamCalPulse &calPulseParams)
 {
     req = wisc::RPCMsg("calibration_routines.genChannelScan");
 
-    req.set_word("nevts", nevts);
-    req.set_word("ohN", ohN);
-    req.set_word("mask", mask);
-    req.set_word("dacMin", dacMin);
-    req.set_word("dacMax", dacMax);
-    req.set_word("dacStep", dacStep);
-    req.set_word("useCalPulse", useCalPulse);
-    req.set_word("currentPulse", currentPulse);
-    req.set_word("calScaleFactor", calScaleFactor);
-    req.set_word("useExtTrig", useExtTrig);
-    if(useUltra){
-        req.set_word("useUltra", useUltra);
+    req.set_word("nevts",scanParams.nevts);
+    req.set_word("ohN",scanParams.ohN);
+    req.set_word("mask",scanParams.vfatMask);
+    req.set_word("dacMin",scanParams.dacMin);
+    req.set_word("dacMax",scanParams.dacMax);
+    req.set_word("dacStep",scanParams.dacStep);
+    if(scanParams.useUltra){
+        req.set_word("useUltra",scanParams.useUltra);
     }
-    req.set_string("scanReg", std::string(scanReg));
+    req.set_word("useExtTrig",scanParams.useExtTrig);
+    req.set_string("scanReg",scanParams.scanReg);
+
+    req.set_word("useCalPulse", calPulseParams.enable);
+    req.set_word("currentPulse", calPulseParams.isCurrent);
+    req.set_word("calScaleFactor", calPulseParams.scaleFactor);
+
+    uint32_t dataSize = sizeof(uint32_t)*24*128*(scanParams.dacMax-scanParams.dacMin+1)/scanParams.dacStep;
+    if(dataSize > 65535){
+        throw std::length_error("dataSize for generic channel scan exceeds TCP/IP maximum packet size, please try to run again for a smaller scan range");
+    }
 
     try {
         rsp = rpc.call_method(req);
@@ -158,107 +158,102 @@ uint32_t xhal::rpc::CalRoutines::genChannelScan(uint32_t nevts, uint32_t ohN, ui
     STANDARD_CATCH;
 
     if (rsp.get_key_exists("error")) {
-        printf("Caught an error: %s\n", (rsp.get_string("error")).c_str());
-        return 1;
-    }
-    const uint32_t size = 24*128*(dacMax-dacMin+1)/dacStep;
-    if (rsp.get_key_exists("data")) {
-        ASSERT(rsp.get_word_array_size("data") == size);
-        rsp.get_word_array("data", result);
-    } else {
-        printf("No data key found");
-        return 1;
+        throw xhal::utils::Exception(strcat("RPC exception: ", rsp.get_string("error").c_str()));
     }
 
-    return 0;
+    PyListUint32 data;
+    if (rsp.get_key_exists("data")) {
+        data = rsp.get_word_array("data");
+    } else {
+        throw xhal::utils::Exception("RPC exception: no data from generic channel scan found");
+    }
+
+    return data;
 } //End genChannelScan()
 
-uint32_t xhal::rpc::CalRoutines::sbitRateScan(uint32_t ohN, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep, uint32_t ch, uint32_t maskOh, bool invertVFATPos, char * scanReg, uint32_t waitTime, uint32_t * resultDacVal, uint32_t * resultTrigRate, uint32_t * resultTrigRatePerVFAT, bool isParallel)
+PyDictVecUint32<std::string> xhal::rpc::CalRoutines::sbitRateScan(xhal::ParamScan &scanParams, bool invertVFATPos, bool isParallel)
 {
     req = wisc::RPCMsg("calibration_routines.sbitRateScan");
 
 
-    req.set_word("ohN", ohN);
-    req.set_word("maskOh", maskOh);
+    req.set_word("ohN",scanParams.ohN);
+    req.set_word("mask",scanParams.vfatMask);
+    req.set_word("dacMin",scanParams.dacMin);
+    req.set_word("dacMax",scanParams.dacMax);
+    req.set_word("dacStep",scanParams.dacStep);
+    req.set_word("ch",scanParams.chan);
+    req.set_string("scanReg",scanParams.scanReg);
+    req.set_word("waitTime",scanParams.waitTime);
+
     req.set_word("invertVFATPos", invertVFATPos);
     req.set_word("isParallel", isParallel);
-    req.set_word("dacMin", dacMin);
-    req.set_word("dacMax", dacMax);
-    req.set_word("dacStep", dacStep);
-    req.set_word("ch", ch);
-    req.set_string("scanReg", std::string(scanReg));
-    req.set_word("waitTime", waitTime);
 
     //Check to make sure (dacMax-dacMin+1)/dacStep is an integer!
-    if( 0 != ((dacMax - dacMin + 1) % dacStep) ){
-        printf("Caught an error: (dacMax - dacMin + 1)/dacStep must be an integer!\n");
-        return 1;
+    if( 0 != ((scanParams.dacMax - scanParams.dacMin + 1) % scanParams.dacStep) ){
+        throw std::logic_error("Caught an error: (dacMax - dacMin + 1)/dacStep must be an integer!");
     }
-    const uint32_t size = (dacMax - dacMin+1)/dacStep;
 
     try {
         rsp = rpc.call_method(req);
     }
     STANDARD_CATCH;
 
+    PyDictVecUint32<std::string> ret_dictRateData;
     if (rsp.get_key_exists("error")) {
-        printf("Caught an error: %s\n", (rsp.get_string("error")).c_str());
-        return 1;
+        throw xhal::utils::Exception(strcat("RPC exception: ", rsp.get_string("error").c_str()));
     }
 
-    if (rsp.get_key_exists("data_dacVal")) {
-        ASSERT(rsp.get_word_array_size("data_dacVal") == size);
-        rsp.get_word_array("data_dacVal", resultDacVal);
+    if (rsp.get_key_exists("outDataDacValue")) {
+        ret_dictRateData["DACVAL"] = rsp.get_word_array("outDataDacValue");
     } else {
-        printf("No key found for data dac values");
-        return 1;
+        throw xhal::utils::Exception("RPC exception: no dac values from sbit rate scan found");
     }
 
-    if (rsp.get_key_exists("data_trigRate")) {
-        ASSERT(rsp.get_word_array_size("data_trigRate") == size);
-        rsp.get_word_array("data_trigRate", resultTrigRate);
+    if (rsp.get_key_exists("outDataCTP7Rate")) {
+        ret_dictRateData["CTP7Rate"] = rsp.get_word_array("outDataCTP7Rate");
     } else {
-        printf("No key found for data trigger rate values");
-        return 1;
+        throw xhal::utils::Exception("RPC exception: no data for CTP7 rate from sbit rate scan found");
     }
 
     if(isParallel){
-        if (rsp.get_key_exists("data_trigRatePerVFAT")) {
-            ASSERT(rsp.get_word_array_size("data_trigRatePerVFAT") == (size*24));
-            rsp.get_word_array("data_trigRatePerVFAT", resultTrigRatePerVFAT);
+        if (rsp.get_key_exists("outDataVFATRate")) {
+            ret_dictRateData["VFATRate"] = rsp.get_word_array("outDataVFATRate");
         }
         else{
-            printf("No key found for data trigger rate per vfat values");
-            return 1;
+            throw xhal::utils::Exception("RPC exception: no data for VFAT rate from sbit rate scan found");
         }
     }
 
-    return 0;
+    return ret_dictRateData;
 } //End sbitRateScan(...)
 
-uint32_t xhal::rpc::CalRoutines::ttcGenConf(uint32_t ohN, uint32_t mode, uint32_t type, uint32_t pulseDelay, uint32_t L1Ainterval, uint32_t nPulses, bool enable)
+void xhal::rpc::CalRoutines::ttcGenConf(uint32_t ohN, xhal::ParamTtcGen &ttcGenParams)
 {
 
     req = wisc::RPCMsg("calibration_routines.ttcGenConf");
+
     req.set_word("ohN", ohN);
-    req.set_word("mode", mode);
-    req.set_word("type", type);
-    req.set_word("pulseDelay", pulseDelay);
-    req.set_word("L1Ainterval", L1Ainterval);
-    req.set_word("nPulses", nPulses);
-    req.set_word("enable", enable);
+
+    req.set_word("mode",ttcGenParams.mode);
+    req.set_word("type",ttcGenParams.type);
+    req.set_word("pulseDelay",ttcGenParams.pulseDelay);
+    req.set_word("L1Ainterval",ttcGenParams.L1Ainterval);
+    req.set_word("nPulses",ttcGenParams.nPulses);
+    req.set_word("enable",ttcGenParams.enable);
+
     try {
         rsp = rpc.call_method(req);
     }
     STANDARD_CATCH;
 
     if (rsp.get_key_exists("error")) {
-        return 1;
+        throw xhal::utils::Exception(strcat("RPC exception: ", rsp.get_string("error").c_str()));
     }
-    return 0;
+
+    return;
 }
 
-uint32_t xhal::rpc::CalRoutines::ttcGenToggle(uint32_t ohN, bool enable)
+void xhal::rpc::CalRoutines::ttcGenToggle(uint32_t ohN, bool enable)
 {
     req = wisc::RPCMsg("calibration_routines.ttcGenToggle");
     req.set_word("ohN", ohN);
@@ -269,7 +264,8 @@ uint32_t xhal::rpc::CalRoutines::ttcGenToggle(uint32_t ohN, bool enable)
     STANDARD_CATCH;
 
     if (rsp.get_key_exists("error")) {
-        return 1;
+        throw xhal::utils::Exception(strcat("RPC exception: ", rsp.get_string("error").c_str()));
     }
-    return 0;
+
+    return;
 } //End ttcGenToggle(...)

--- a/xhalcore/src/common/rpc_manager/daq_monitor.cpp
+++ b/xhalcore/src/common/rpc_manager/daq_monitor.cpp
@@ -8,7 +8,7 @@ PyListUint32 xhal::rpc::DaqMonitor::getmonTTCmain()
     	rsp = rpc.call_method(req);
     }
     STANDARD_CATCH;
-    
+
     try{
         if (rsp.get_key_exists("error")) {
             printf("Error: %s",rsp.get_string("error").c_str());
@@ -195,3 +195,82 @@ PyListUint32 xhal::rpc::DaqMonitor::getmonOHmain(uint32_t noh)
     STANDARD_CATCH;
     return result;
 }
+
+//PyDictVecUint32<int> xhal::rpc::DaqMonitor::getmonOHSCAmain(uint32_t noh, uint32_t ohMask){
+NestedPyDict<int,PyDictUint32<std::string> > xhal::rpc::DaqMonitor::getmonOHSCAmain(uint32_t noh, uint32_t ohMask){
+    req = wisc::RPCMsg("amc.getmonOHSCAmain");
+
+    req.set_word("NOH",noh);
+    req.set_word("ohMask",ohMask);
+    try {
+        rsp = rpc.call_method(req);
+    }
+    STANDARD_CATCH;
+
+    //PyDictVecUint32<int> ret_Dict; //Key is ohN, value is a list
+    NestedPyDict<int,PyDictUint32<std::string> > ret_nestedDict;
+    try{
+        if (rsp.get_key_exists("error")) { //Case Error Exists
+            printf("Error: %s",rsp.get_string("error").c_str());
+            // FIXME raise an exception
+        } //End Case: Error Exists
+        else { //Case: No Error
+            for(int ohN = 0; ohN < noh; ++ohN){ //Loop over number of optohybrids
+                // If this Optohybrid is masked skip it
+                if(((ohMask >> ohN) & 0x0)){
+                    continue;
+                }
+
+                PyDictUint32<std::string> scaVals4ohN;
+                //std::string strKeyName;
+                std::string strOhN = std::to_string(ohN);
+
+                //SCA Temperature
+                scaVals4ohN["SCA_TEMP"] = rsp.get_word("OH" + strOhN + "SCA_TEMP");
+
+                //OH Temperature Sensors
+                for(int tempVal=1; tempVal <= 9; ++tempVal){ //Loop over optohybrid temperature sensors
+                    std::string strTempVal = std::to_string(tempVal);
+                    scaVals4ohN["BOARD_TEMP"+strTempVal]=rsp.get_word("OH" + strOhN + "BOARD_TEMP" + strTempVal);
+                } //End Loop over optohybrid temperature sensors
+
+                //Voltage Monitor - AVCCN
+                scaVals4ohN["AVCCN"] = rsp.get_word("OH" + strOhN + "AVCCN");
+
+                //Voltage Monitor - AVTTN
+                scaVals4ohN["AVTTN"] = rsp.get_word("OH" + strOhN + "AVTTN");
+
+                //Voltage Monitor - 1V0_INT
+                scaVals4ohN["1V0_INT"] = rsp.get_word("OH" + strOhN + "1V0_INT");
+
+                //Voltage Monitor - 1V8F
+                scaVals4ohN["1V8F"] = rsp.get_word("OH" + strOhN + "1V8F");
+
+                //Voltage Monitor - 1V5
+                scaVals4ohN["1V5"] = rsp.get_word("OH" + strOhN + "1V5");
+
+                //Voltage Monitor - 2V5_IO
+                scaVals4ohN["2V5_IO"] = rsp.get_word("OH" + strOhN + "2V5_IO");
+
+                //Voltage Monitor - 3V0
+                scaVals4ohN["3V0"] = rsp.get_word("OH" + strOhN + "3V0");
+
+                //Voltage Monitor - 1V8
+                scaVals4ohN["1V8"] = rsp.get_word("OH" + strOhN + "1V8");
+
+                //Voltage Monitor - VTRX_RSSI2
+                scaVals4ohN["VTRX_RSSI2"] = rsp.get_word("OH" + strOhN + "VTRX_RSSI2");
+
+                //Voltage Monitor - VTRX_RSSI1
+                scaVals4ohN["VTRX_RSSI1"] = rsp.get_word("OH" + strOhN + "VTRX_RSSI1");
+
+                //Store this in output map
+                ret_nestedDict[ohN] = scaVals4ohN;
+            } // End loop over number of optohybrids
+        } //End Case: No Error
+    }
+    STANDARD_CATCH;
+
+    //return ret_Dict;
+    return ret_nestedDict;
+} //End xhal::rpc::DaqMonitor::getmonOHSCAmain

--- a/xhalcore/src/common/rpc_manager/daq_monitor.cpp
+++ b/xhalcore/src/common/rpc_manager/daq_monitor.cpp
@@ -11,7 +11,7 @@ PyListUint32 xhal::rpc::DaqMonitor::getmonTTCmain()
 
     try{
         if (rsp.get_key_exists("error")) {
-            throw xhal::utils::Exception(strcat("RPC exception: ", rsp.get_string("error").c_str()));
+            throw xhal::utils::XHALRPCException(strcat("RPC exception: ", rsp.get_string("error").c_str()));
         } else {
             result.clear();
             result.push_back(rsp.get_word("MMCM_LOCKED"));
@@ -37,7 +37,7 @@ PyListUint32 xhal::rpc::DaqMonitor::getmonTRIGGERmain(uint32_t noh)
 
     try{
         if (rsp.get_key_exists("error")) {
-            throw xhal::utils::Exception(strcat("RPC exception: ", rsp.get_string("error").c_str()));
+            throw xhal::utils::XHALRPCException(strcat("RPC exception: ", rsp.get_string("error").c_str()));
         } else {
             std::string t;
             result.push_back(rsp.get_word("OR_TRIGGER_RATE"));
@@ -63,7 +63,7 @@ PyListUint32 xhal::rpc::DaqMonitor::getmonTRIGGEROHmain(uint32_t noh)
 
     try{
         if (rsp.get_key_exists("error")) {
-            throw xhal::utils::Exception(strcat("RPC exception: ", rsp.get_string("error").c_str()));
+            throw xhal::utils::XHALRPCException(strcat("RPC exception: ", rsp.get_string("error").c_str()));
         }else {
             std::string t;
             for (unsigned int i = 0; i < noh; i++) {
@@ -101,7 +101,7 @@ PyListUint32 xhal::rpc::DaqMonitor::getmonDAQmain()
 
     try{
         if (rsp.get_key_exists("error")) {
-            throw xhal::utils::Exception(strcat("RPC exception: ", rsp.get_string("error").c_str()));
+            throw xhal::utils::XHALRPCException(strcat("RPC exception: ", rsp.get_string("error").c_str()));
         } else {
             result.push_back(rsp.get_word("DAQ_ENABLE"));
             result.push_back(rsp.get_word("DAQ_LINK_READY"));
@@ -130,7 +130,7 @@ PyListUint32 xhal::rpc::DaqMonitor::getmonDAQOHmain(uint32_t noh)
 
     try{
         if (rsp.get_key_exists("error")) {
-            throw xhal::utils::Exception(strcat("RPC exception: ", rsp.get_string("error").c_str()));
+            throw xhal::utils::XHALRPCException(strcat("RPC exception: ", rsp.get_string("error").c_str()));
         }else {
             std::string t;
             for (unsigned int i = 0; i < noh; i++) {
@@ -165,7 +165,7 @@ PyListUint32 xhal::rpc::DaqMonitor::getmonOHmain(uint32_t noh)
 
     try{
         if (rsp.get_key_exists("error")) {
-            throw xhal::utils::Exception(strcat("RPC exception: ", rsp.get_string("error").c_str()));
+            throw xhal::utils::XHALRPCException(strcat("RPC exception: ", rsp.get_string("error").c_str()));
         } else {
             std::string t;
             for (unsigned int i = 0; i < noh; i++) {
@@ -204,7 +204,7 @@ NestedPyDict<int,PyDictUint32<std::string> > xhal::rpc::DaqMonitor::getmonOHSCAm
     NestedPyDict<int,PyDictUint32<std::string> > ret_nestedDict;
     try{
         if (rsp.get_key_exists("error")) { //Case Error Exists
-            throw xhal::utils::Exception(strcat("RPC exception: ", rsp.get_string("error").c_str()));
+            throw xhal::utils::XHALRPCException(strcat("RPC exception: ", rsp.get_string("error").c_str()));
         } //End Case: Error Exists
         else { //Case: No Error
             for(int ohN = 0; ohN < noh; ++ohN){ //Loop over number of optohybrids

--- a/xhalcore/src/common/rpc_manager/daq_monitor.cpp
+++ b/xhalcore/src/common/rpc_manager/daq_monitor.cpp
@@ -11,8 +11,7 @@ PyListUint32 xhal::rpc::DaqMonitor::getmonTTCmain()
 
     try{
         if (rsp.get_key_exists("error")) {
-            printf("Error: %s",rsp.get_string("error").c_str());
-            //FIXME raise an exception
+            throw xhal::utils::Exception(strcat("RPC exception: ", rsp.get_string("error").c_str()));
         } else {
             result.clear();
             result.push_back(rsp.get_word("MMCM_LOCKED"));
@@ -38,8 +37,7 @@ PyListUint32 xhal::rpc::DaqMonitor::getmonTRIGGERmain(uint32_t noh)
 
     try{
         if (rsp.get_key_exists("error")) {
-            printf("Error: %s",rsp.get_string("error").c_str());
-            // FIXME raise an exception
+            throw xhal::utils::Exception(strcat("RPC exception: ", rsp.get_string("error").c_str()));
         } else {
             std::string t;
             result.push_back(rsp.get_word("OR_TRIGGER_RATE"));
@@ -65,8 +63,7 @@ PyListUint32 xhal::rpc::DaqMonitor::getmonTRIGGEROHmain(uint32_t noh)
 
     try{
         if (rsp.get_key_exists("error")) {
-            printf("Error: %s",rsp.get_string("error").c_str());
-            // FIXME raise an exception
+            throw xhal::utils::Exception(strcat("RPC exception: ", rsp.get_string("error").c_str()));
         }else {
             std::string t;
             for (unsigned int i = 0; i < noh; i++) {
@@ -104,8 +101,7 @@ PyListUint32 xhal::rpc::DaqMonitor::getmonDAQmain()
 
     try{
         if (rsp.get_key_exists("error")) {
-            printf("Error: %s",rsp.get_string("error").c_str());
-            // FIXME raise an exception
+            throw xhal::utils::Exception(strcat("RPC exception: ", rsp.get_string("error").c_str()));
         } else {
             result.push_back(rsp.get_word("DAQ_ENABLE"));
             result.push_back(rsp.get_word("DAQ_LINK_READY"));
@@ -134,8 +130,7 @@ PyListUint32 xhal::rpc::DaqMonitor::getmonDAQOHmain(uint32_t noh)
 
     try{
         if (rsp.get_key_exists("error")) {
-            printf("Error: %s",rsp.get_string("error").c_str());
-            // FIXME raise an exception
+            throw xhal::utils::Exception(strcat("RPC exception: ", rsp.get_string("error").c_str()));
         }else {
             std::string t;
             for (unsigned int i = 0; i < noh; i++) {
@@ -170,8 +165,7 @@ PyListUint32 xhal::rpc::DaqMonitor::getmonOHmain(uint32_t noh)
 
     try{
         if (rsp.get_key_exists("error")) {
-            printf("Error: %s",rsp.get_string("error").c_str());
-            // FIXME raise an exception
+            throw xhal::utils::Exception(strcat("RPC exception: ", rsp.get_string("error").c_str()));
         } else {
             std::string t;
             for (unsigned int i = 0; i < noh; i++) {
@@ -196,7 +190,6 @@ PyListUint32 xhal::rpc::DaqMonitor::getmonOHmain(uint32_t noh)
     return result;
 }
 
-//PyDictVecUint32<int> xhal::rpc::DaqMonitor::getmonOHSCAmain(uint32_t noh, uint32_t ohMask){
 NestedPyDict<int,PyDictUint32<std::string> > xhal::rpc::DaqMonitor::getmonOHSCAmain(uint32_t noh, uint32_t ohMask){
     req = wisc::RPCMsg("amc.getmonOHSCAmain");
 
@@ -211,8 +204,7 @@ NestedPyDict<int,PyDictUint32<std::string> > xhal::rpc::DaqMonitor::getmonOHSCAm
     NestedPyDict<int,PyDictUint32<std::string> > ret_nestedDict;
     try{
         if (rsp.get_key_exists("error")) { //Case Error Exists
-            printf("Error: %s",rsp.get_string("error").c_str());
-            // FIXME raise an exception
+            throw xhal::utils::Exception(strcat("RPC exception: ", rsp.get_string("error").c_str()));
         } //End Case: Error Exists
         else { //Case: No Error
             for(int ohN = 0; ohN < noh; ++ohN){ //Loop over number of optohybrids
@@ -271,6 +263,5 @@ NestedPyDict<int,PyDictUint32<std::string> > xhal::rpc::DaqMonitor::getmonOHSCAm
     }
     STANDARD_CATCH;
 
-    //return ret_Dict;
     return ret_nestedDict;
 } //End xhal::rpc::DaqMonitor::getmonOHSCAmain

--- a/xhalcore/src/common/rpc_manager/optohybrid.cpp
+++ b/xhalcore/src/common/rpc_manager/optohybrid.cpp
@@ -6,7 +6,7 @@ xhal::rpc::Optohybrid::Optohybrid(const std::string& board_domain_name, const st
   this->loadModule("optohybrid","optohybrid v1.0.1");
 }
 
-uint32_t xhal::rpc::Optohybrid::broadcastRead(uint32_t ohN, char * regName, uint32_t vfatMask, uint32_t * result)
+PyListUint32 xhal::rpc::Optohybrid::broadcastRead(uint32_t ohN, std::string &regName, uint32_t vfatMask)
 {
     /* User supplies the VFAT node name as reg_name, examples:
      *
@@ -18,7 +18,7 @@ uint32_t xhal::rpc::Optohybrid::broadcastRead(uint32_t ohN, char * regName, uint
 
     req = wisc::RPCMsg("optohybrid.broadcastRead");
 
-    req.set_string("reg_name",std::string(regName));
+    req.set_string("reg_name",regName);
     req.set_word("ohN",ohN);
     req.set_word("mask",vfatMask);
 
@@ -27,22 +27,20 @@ uint32_t xhal::rpc::Optohybrid::broadcastRead(uint32_t ohN, char * regName, uint
     }
     STANDARD_CATCH;
 
+    PyListUint32 data;
     if (rsp.get_key_exists("error")) {
-        printf("Caught an error: %s\n", (rsp.get_string("error")).c_str());
-        return 1;
+        throw xhal::utils::Exception(strcat("RPC exception: ", rsp.get_string("error").c_str()));
     }
     else if (rsp.get_key_exists("data")) {
-        const uint32_t size = 24;
-        ASSERT(rsp.get_word_array_size("data") == size);
-        rsp.get_word_array("data", result);
+        data = rsp.get_word_array("data");
     } else {
-        printf("No data key found");
-        return 1;
+        throw xhal::utils::Exception("RPC exception: no data found from broadcast read");
     }
-    return 0;
+
+    return data;
 } //End broadcastRead
 
-uint32_t xhal::rpc::Optohybrid::broadcastWrite(uint32_t ohN, char * regName, uint32_t value, uint32_t vfatMask)
+void xhal::rpc::Optohybrid::broadcastWrite(uint32_t ohN, std::string &regName, uint32_t value, uint32_t vfatMask)
 {
     /* User supplies the VFAT node name as reg_name, examples:
      *
@@ -54,7 +52,7 @@ uint32_t xhal::rpc::Optohybrid::broadcastWrite(uint32_t ohN, char * regName, uin
 
     req = wisc::RPCMsg("optohybrid.broadcastWrite");
 
-    req.set_string("reg_name",std::string(regName));
+    req.set_string("reg_name",regName);
     req.set_word("ohN",ohN);
     req.set_word("value",value);
     req.set_word("mask",vfatMask);
@@ -65,30 +63,30 @@ uint32_t xhal::rpc::Optohybrid::broadcastWrite(uint32_t ohN, char * regName, uin
     STANDARD_CATCH;
 
     if (rsp.get_key_exists("error")) {
-        printf("Caught an error: %s\n", (rsp.get_string("error")).c_str());
-        return 1;
+        throw xhal::utils::Exception(strcat("RPC exception: ", rsp.get_string("error").c_str()));
     }
-    return 0;
+
+    return;
 }
 
-uint32_t xhal::rpc::Optohybrid::configureScanModule(uint32_t ohN, uint32_t vfatN, uint32_t scanmode, bool useUltra, uint32_t vfatMask, uint32_t ch, uint32_t nevts, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep)
+void xhal::rpc::Optohybrid::configureScanModule(xhal::ParamScan &scanParams, uint32_t scanmode)
 {
     req = wisc::RPCMsg("optohybrid.configureScanModule");
 
-    req.set_word("ohN",ohN);
+    req.set_word("ohN",scanParams.ohN);
     req.set_word("scanmode",scanmode);
-    if (useUltra){
-        req.set_word("useUltra",useUltra);
-        req.set_word("mask",vfatMask);
+    if (scanParams.useUltra){
+        req.set_word("useUltra",scanParams.useUltra);
+        req.set_word("mask",scanParams.vfatMask);
     }
     else{
-        req.set_word("vfatN",vfatN);
+        req.set_word("vfatN",scanParams.vfatN);
     }
-    req.set_word("ch", ch); //channel
-    req.set_word("nevts",nevts);
-    req.set_word("dacMin",dacMin);
-    req.set_word("dacMax",dacMax);
-    req.set_word("dacStep",dacStep);
+    req.set_word("ch",scanParams.chan); //channel
+    req.set_word("nevts",scanParams.nevts);
+    req.set_word("dacMin",scanParams.dacMin);
+    req.set_word("dacMax",scanParams.dacMax);
+    req.set_word("dacStep",scanParams.dacStep);
 
     try {
         rsp = rpc.call_method(req);
@@ -96,14 +94,13 @@ uint32_t xhal::rpc::Optohybrid::configureScanModule(uint32_t ohN, uint32_t vfatN
     STANDARD_CATCH;
 
     if (rsp.get_key_exists("error")) {
-        printf("Caught an error: %s\n", (rsp.get_string("error")).c_str());
-        return 1;
+        throw xhal::utils::Exception(strcat("RPC exception: ", rsp.get_string("error").c_str()));
     }
 
-    return 0;
+    return;
 } //End configureScanModule(...)
 
-uint32_t xhal::rpc::Optohybrid::printScanConfiguration(uint32_t ohN, bool useUltra)
+void xhal::rpc::Optohybrid::printScanConfiguration(uint32_t ohN, bool useUltra)
 {
     req = wisc::RPCMsg("optohybrid.printScanConfiguration");
 
@@ -118,14 +115,13 @@ uint32_t xhal::rpc::Optohybrid::printScanConfiguration(uint32_t ohN, bool useUlt
     STANDARD_CATCH;
 
     if (rsp.get_key_exists("error")) {
-        printf("Caught an error: %s\n", (rsp.get_string("error")).c_str());
-        return 1;
+        throw xhal::utils::Exception(strcat("RPC exception: ", rsp.get_string("error").c_str()));
     }
 
-    return 0;
+    return;
 } //End printScanConfiguration(...)
 
-uint32_t xhal::rpc::Optohybrid::startScanModule(uint32_t ohN, bool useUltra)
+void xhal::rpc::Optohybrid::startScanModule(uint32_t ohN, bool useUltra)
 {
     req = wisc::RPCMsg("optohybrid.startScanModule");
 
@@ -140,22 +136,21 @@ uint32_t xhal::rpc::Optohybrid::startScanModule(uint32_t ohN, bool useUltra)
     STANDARD_CATCH;
 
     if (rsp.get_key_exists("error")) {
-        printf("Caught an error: %s\n", (rsp.get_string("error")).c_str());
-        return 1;
+        throw xhal::utils::Exception(strcat("RPC exception: ", rsp.get_string("error").c_str()));
     }
 
-    return 0;
+    return;
 } //End startScanModule(...)
 
-uint32_t xhal::rpc::Optohybrid::getUltraScanResults(uint32_t ohN, uint32_t nevts, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep, uint32_t * result)
+PyListUint32 xhal::rpc::Optohybrid::getUltraScanResults(xhal::ParamScan &scanParams)
 {
     req = wisc::RPCMsg("optohybrid.getUltraScanResults");
 
-    req.set_word("ohN",ohN);
-    req.set_word("nevts",nevts);
-    req.set_word("dacMin",dacMin);
-    req.set_word("dacMax",dacMax);
-    req.set_word("dacStep",dacStep);
+    req.set_word("ohN",scanParams.ohN);
+    req.set_word("nevts",scanParams.nevts);
+    req.set_word("dacMin",scanParams.dacMin);
+    req.set_word("dacMax",scanParams.dacMax);
+    req.set_word("dacStep",scanParams.dacStep);
 
     try {
         rsp = rpc.call_method(req);
@@ -163,22 +158,20 @@ uint32_t xhal::rpc::Optohybrid::getUltraScanResults(uint32_t ohN, uint32_t nevts
     STANDARD_CATCH;
 
     if (rsp.get_key_exists("error")) {
-        printf("Caught an error: %s\n", (rsp.get_string("error")).c_str());
-        return 1;
-    }
-    const uint32_t size = (dacMax - dacMin+1)*24/dacStep;
-    if (rsp.get_key_exists("data")) {
-        ASSERT(rsp.get_word_array_size("data") == size);
-        rsp.get_word_array("data", result);
-    } else {
-        printf("No data key found");
-        return 1;
+        throw xhal::utils::Exception(strcat("RPC exception: ", rsp.get_string("error").c_str()));
     }
 
-    return 0;
+    PyListUint32 data;
+    if (rsp.get_key_exists("data")) {
+        data = rsp.get_word_array("data");
+    } else {
+        throw xhal::utils::Exception("RPC exception: no data found in ultra scan results");
+    }
+
+    return data;
 } //End getUltraScanResults(...)
 
-uint32_t xhal::rpc::Optohybrid::stopCalPulse2AllChannels(uint32_t ohN, uint32_t mask, uint32_t ch_min, uint32_t ch_max)
+void xhal::rpc::Optohybrid::stopCalPulse2AllChannels(uint32_t ohN, uint32_t mask, uint32_t ch_min, uint32_t ch_max)
 {
     req = wisc::RPCMsg("optohybrid.stopCalPulse2AllChannels");
 
@@ -193,9 +186,8 @@ uint32_t xhal::rpc::Optohybrid::stopCalPulse2AllChannels(uint32_t ohN, uint32_t 
     STANDARD_CATCH;
 
     if (rsp.get_key_exists("error")) {
-        printf("Caught an error: %s\n", (rsp.get_string("error")).c_str());
-        return 1;
+        throw xhal::utils::Exception(strcat("RPC exception: ", rsp.get_string("error").c_str()));
     }
 
-    return 0;
+    return;
 }

--- a/xhalcore/src/common/rpc_manager/optohybrid.cpp
+++ b/xhalcore/src/common/rpc_manager/optohybrid.cpp
@@ -3,6 +3,7 @@
 xhal::rpc::Optohybrid::Optohybrid(const std::string& board_domain_name, const std::string& address_table_filename):
   xhal::XHALDevice(board_domain_name, address_table_filename)
 {
+  m_map_modName_modVer["optohybrid"]="optohybrid v1.0.1";
   this->loadModule("optohybrid","optohybrid v1.0.1");
 }
 

--- a/xhalcore/src/common/rpc_manager/optohybrid.cpp
+++ b/xhalcore/src/common/rpc_manager/optohybrid.cpp
@@ -30,12 +30,12 @@ PyListUint32 xhal::rpc::Optohybrid::broadcastRead(uint32_t ohN, std::string &reg
 
     PyListUint32 data;
     if (rsp.get_key_exists("error")) {
-        throw xhal::utils::Exception(strcat("RPC exception: ", rsp.get_string("error").c_str()));
+        throw xhal::utils::XHALRPCException(strcat("RPC exception: ", rsp.get_string("error").c_str()));
     }
     else if (rsp.get_key_exists("data")) {
         data = rsp.get_word_array("data");
     } else {
-        throw xhal::utils::Exception("RPC exception: no data found from broadcast read");
+        throw xhal::utils::XHALRPCException("RPC exception: no data found from broadcast read");
     }
 
     return data;
@@ -64,7 +64,7 @@ void xhal::rpc::Optohybrid::broadcastWrite(uint32_t ohN, std::string &regName, u
     STANDARD_CATCH;
 
     if (rsp.get_key_exists("error")) {
-        throw xhal::utils::Exception(strcat("RPC exception: ", rsp.get_string("error").c_str()));
+        throw xhal::utils::XHALRPCException(strcat("RPC exception: ", rsp.get_string("error").c_str()));
     }
 
     return;
@@ -95,7 +95,7 @@ void xhal::rpc::Optohybrid::configureScanModule(xhal::ParamScan &scanParams, uin
     STANDARD_CATCH;
 
     if (rsp.get_key_exists("error")) {
-        throw xhal::utils::Exception(strcat("RPC exception: ", rsp.get_string("error").c_str()));
+        throw xhal::utils::XHALRPCException(strcat("RPC exception: ", rsp.get_string("error").c_str()));
     }
 
     return;
@@ -116,7 +116,7 @@ void xhal::rpc::Optohybrid::printScanConfiguration(uint32_t ohN, bool useUltra)
     STANDARD_CATCH;
 
     if (rsp.get_key_exists("error")) {
-        throw xhal::utils::Exception(strcat("RPC exception: ", rsp.get_string("error").c_str()));
+        throw xhal::utils::XHALRPCException(strcat("RPC exception: ", rsp.get_string("error").c_str()));
     }
 
     return;
@@ -137,7 +137,7 @@ void xhal::rpc::Optohybrid::startScanModule(uint32_t ohN, bool useUltra)
     STANDARD_CATCH;
 
     if (rsp.get_key_exists("error")) {
-        throw xhal::utils::Exception(strcat("RPC exception: ", rsp.get_string("error").c_str()));
+        throw xhal::utils::XHALRPCException(strcat("RPC exception: ", rsp.get_string("error").c_str()));
     }
 
     return;
@@ -159,14 +159,14 @@ PyListUint32 xhal::rpc::Optohybrid::getUltraScanResults(xhal::ParamScan &scanPar
     STANDARD_CATCH;
 
     if (rsp.get_key_exists("error")) {
-        throw xhal::utils::Exception(strcat("RPC exception: ", rsp.get_string("error").c_str()));
+        throw xhal::utils::XHALRPCException(strcat("RPC exception: ", rsp.get_string("error").c_str()));
     }
 
     PyListUint32 data;
     if (rsp.get_key_exists("data")) {
         data = rsp.get_word_array("data");
     } else {
-        throw xhal::utils::Exception("RPC exception: no data found in ultra scan results");
+        throw xhal::utils::XHALRPCException("RPC exception: no data found in ultra scan results");
     }
 
     return data;
@@ -187,7 +187,7 @@ void xhal::rpc::Optohybrid::stopCalPulse2AllChannels(uint32_t ohN, uint32_t mask
     STANDARD_CATCH;
 
     if (rsp.get_key_exists("error")) {
-        throw xhal::utils::Exception(strcat("RPC exception: ", rsp.get_string("error").c_str()));
+        throw xhal::utils::XHALRPCException(strcat("RPC exception: ", rsp.get_string("error").c_str()));
     }
 
     return;

--- a/xhalcore/src/common/rpc_manager/vfat3.cpp
+++ b/xhalcore/src/common/rpc_manager/vfat3.cpp
@@ -23,7 +23,7 @@ void xhal::rpc::VFAT3::configureVFAT3s(uint32_t ohN, uint32_t vfatMask)
     STANDARD_CATCH;
 
     if (rsp.get_key_exists("error")) {
-        throw xhal::utils::Exception(strcat("RPC exception: ", rsp.get_string("error").c_str()));
+        throw xhal::utils::XHALRPCException(strcat("RPC exception: ", rsp.get_string("error").c_str()));
     }
     return;
 }
@@ -41,7 +41,7 @@ void xhal::rpc::VFAT3::configureVFAT3DacMonitor(uint32_t ohN, uint32_t vfatMask,
     STANDARD_CATCH;
 
     if (rsp.get_key_exists("error")) {
-        throw xhal::utils::Exception(strcat("RPC exception: ", rsp.get_string("error").c_str()));
+        throw xhal::utils::XHALRPCException(strcat("RPC exception: ", rsp.get_string("error").c_str()));
     }
     return;
 } //End configureVFAT3DacMonitor(...)
@@ -63,7 +63,7 @@ void xhal::rpc::VFAT3::configureVFAT3DacMonitorMultiLink(uint32_t ohMask, PyList
     STANDARD_CATCH;
 
     if (rsp.get_key_exists("error")) {
-        throw xhal::utils::Exception(strcat("RPC exception: ", rsp.get_string("error").c_str()));
+        throw xhal::utils::XHALRPCException(strcat("RPC exception: ", rsp.get_string("error").c_str()));
     }
     return;
 } //End configureVFAT3DacMonitor(...)
@@ -80,14 +80,14 @@ PyListUint32 xhal::rpc::VFAT3::getChannelRegistersVFAT3(uint32_t ohN, uint32_t v
     STANDARD_CATCH;
 
     if (rsp.get_key_exists("error")) {
-        throw xhal::utils::Exception(strcat("RPC exception: ", rsp.get_string("error").c_str()));
+        throw xhal::utils::XHALRPCException(strcat("RPC exception: ", rsp.get_string("error").c_str()));
     }
 
     PyListUint32 chanRegData;
     if (rsp.get_key_exists("chanRegData")) {
         chanRegData = rsp.get_word_array("chanRegData");
     } else {
-        throw xhal::utils::Exception("RPC exception: no channel register data found");
+        throw xhal::utils::XHALRPCException("RPC exception: no channel register data found");
     }
 
     return chanRegData;
@@ -106,14 +106,14 @@ PyListUint32 xhal::rpc::VFAT3::readVFAT3ADC(uint32_t ohN, bool useExtRefADC, uin
     STANDARD_CATCH;
 
     if (rsp.get_key_exists("error")) {
-        throw xhal::utils::Exception(strcat("RPC exception: ", rsp.get_string("error").c_str()));
+        throw xhal::utils::XHALRPCException(strcat("RPC exception: ", rsp.get_string("error").c_str()));
     }
 
     PyListUint32 adcData;
     if (rsp.get_key_exists("adcData")) {
         adcData = rsp.get_word_array("adcData");
     } else {
-        throw xhal::utils::Exception("RPC exception: no ADC data found");
+        throw xhal::utils::XHALRPCException("RPC exception: no ADC data found");
     }
 
     return adcData;
@@ -132,14 +132,14 @@ PyListUint32 xhal::rpc::VFAT3::readVFAT3ADCMultiLink(uint32_t ohMask, PyListUint
     STANDARD_CATCH;
 
     if (rsp.get_key_exists("error")) {
-        throw xhal::utils::Exception(strcat("RPC exception: ", rsp.get_string("error").c_str()));
+        throw xhal::utils::XHALRPCException(strcat("RPC exception: ", rsp.get_string("error").c_str()));
     }
 
     PyListUint32 adcDataAll;
     if (rsp.get_key_exists("adcDataAll")) {
         adcDataAll = rsp.get_word_array("adcDataAll");
     } else {
-        throw xhal::utils::Exception("RPC exception: no ADC data found");
+        throw xhal::utils::XHALRPCException("RPC exception: no ADC data found");
     }
 
     return adcDataAll;
@@ -164,7 +164,7 @@ void xhal::rpc::VFAT3::setChannelRegistersVFAT3(uint32_t ohN, uint32_t vfatMask,
     STANDARD_CATCH;
 
     if (rsp.get_key_exists("error")) {
-        throw xhal::utils::Exception(strcat("RPC exception: ", rsp.get_string("error").c_str()));
+        throw xhal::utils::XHALRPCException(strcat("RPC exception: ", rsp.get_string("error").c_str()));
     }
     return;
 }
@@ -184,7 +184,7 @@ void xhal::rpc::VFAT3::setChannelRegistersVFAT3Simple(uint32_t ohN, uint32_t vfa
     STANDARD_CATCH;
 
     if (rsp.get_key_exists("error")) {
-        throw xhal::utils::Exception(strcat("RPC exception: ", rsp.get_string("error").c_str()));
+        throw xhal::utils::XHALRPCException(strcat("RPC exception: ", rsp.get_string("error").c_str()));
     }
     return;
 }

--- a/xhalcore/src/common/rpc_manager/vfat3.cpp
+++ b/xhalcore/src/common/rpc_manager/vfat3.cpp
@@ -25,6 +25,46 @@ uint32_t xhal::rpc::VFAT3::configureVFAT3s(uint32_t ohN, uint32_t vfatMask)
     return 0;
 }
 
+uint32_t xhal::rpc::VFAT3::configureVFAT3DacMonitor(uint32_t ohN, uint32_t vfatMask, uint32_t dacSelect){
+    req = wisc::RPCMsg("vfat3.configureVFAT3DacMonitor");
+
+    req.set_word("ohN",ohN);
+    req.set_word("vfatMask",vfatMask);
+    req.set_word("dacSelect",dacSelect);
+
+    wisc::RPCSvc* rpc_loc = getRPCptr();
+    try {
+        rsp = rpc_loc->call_method(req);
+    }
+    STANDARD_CATCH;
+
+    if (rsp.get_key_exists("error")) {
+        printf("Caught an error: %s\n", (rsp.get_string("error")).c_str());
+        return 1;
+    }
+    return 0;
+} //End configureVFAT3DacMonitor(...)
+
+uint32_t xhal::rpc::VFAT3::configureVFAT3DacMonitorMultiLink(uint32_t ohMask, uint32_t *ohVfatMaskArray, uint32_t dacSelect){
+    req = wisc::RPCMsg("vfat3.configureVFAT3DacMonitorMultiLink");
+
+    req.set_word("ohMask",ohMask);
+    req.set_word_array("ohVfatMaskArray",ohVfatMaskArray,12);
+    req.set_word("dacSelect",dacSelect);
+
+    wisc::RPCSvc* rpc_loc = getRPCptr();
+    try {
+        rsp = rpc_loc->call_method(req);
+    }
+    STANDARD_CATCH;
+
+    if (rsp.get_key_exists("error")) {
+        printf("Caught an error: %s\n", (rsp.get_string("error")).c_str());
+        return 1;
+    }
+    return 0;
+} //End configureVFAT3DacMonitor(...)
+
 uint32_t xhal::rpc::VFAT3::getChannelRegistersVFAT3(uint32_t ohN, uint32_t vfatMask, uint32_t *chanRegData)
 {
     req = wisc::RPCMsg("vfat3.getChannelRegistersVFAT3");
@@ -52,6 +92,66 @@ uint32_t xhal::rpc::VFAT3::getChannelRegistersVFAT3(uint32_t ohN, uint32_t vfatM
 
     return 0;
 }
+
+uint32_t xhal::rpc::VFAT3::readVFAT3ADC(uint32_t ohN, uint32_t *adcData, bool useExtRefADC, uint32_t vfatMask){
+    req = wisc::RPCMsg("vfat3.readVFAT3ADC");
+
+    req.set_word("ohN",ohN);
+    req.set_word("useExtRefADC", useExtRefADC);
+    req.set_word("vfatMask",vfatMask);
+
+    wisc::RPCSvc* rpc_loc = getRPCptr();
+    try {
+        rsp = rpc_loc->call_method(req);
+    }
+    STANDARD_CATCH;
+
+    if (rsp.get_key_exists("error")) {
+        printf("Caught an error: %s\n", (rsp.get_string("error")).c_str());
+        return 1;
+    }
+
+    const uint32_t size = 24;
+    if (rsp.get_key_exists("adcData")) {
+        ASSERT(rsp.get_word_array_size("adcData") == size);
+        rsp.get_word_array("adcData", adcData);
+    } else {
+        printf("No channel register data found");
+        return 1;
+    }
+
+    return 0;
+} //End readVFAT3ADC(...)
+
+uint32_t xhal::rpc::VFAT3::readVFAT3ADCMultiLink(uint32_t ohMask, uint32_t *ohVfatMaskArray, uint32_t *adcDataAll, bool useExtRefADC){
+    req = wisc::RPCMsg("vfat3.readVFAT3ADCMultiLink");
+
+    req.set_word("ohMask",ohMask);
+    req.set_word_array("ohVfatMaskArray",ohVfatMaskArray, 12);
+    req.set_word("useExtRefADC", useExtRefADC);
+
+    wisc::RPCSvc* rpc_loc = getRPCptr();
+    try {
+        rsp = rpc_loc->call_method(req);
+    }
+    STANDARD_CATCH;
+
+    if (rsp.get_key_exists("error")) {
+        printf("Caught an error: %s\n", (rsp.get_string("error")).c_str());
+        return 1;
+    }
+
+    const uint32_t size = 12*24;
+    if (rsp.get_key_exists("adcDataAll")) {
+        ASSERT(rsp.get_word_array_size("adcDataAll") == size);
+        rsp.get_word_array("adcDataAll", adcDataAll);
+    } else {
+        printf("No channel register data found");
+        return 1;
+    }
+
+    return 0;
+} //End readVFAT3ADCMultiLink(...)
 
 uint32_t xhal::rpc::VFAT3::setChannelRegistersVFAT3(uint32_t ohN, uint32_t vfatMask, uint32_t *calEnable, uint32_t *masks, uint32_t *trimARM, uint32_t *trimARMPol, uint32_t *trimZCC, uint32_t *trimZCCPol)
 {

--- a/xhalcore/src/common/rpc_manager/vfat3.cpp
+++ b/xhalcore/src/common/rpc_manager/vfat3.cpp
@@ -7,6 +7,7 @@
 xhal::rpc::VFAT3::VFAT3(const std::string& board_domain_name, const std::string& address_table_filename):
   xhal::XHALDevice(board_domain_name, address_table_filename)
 {
+  m_map_modName_modVer["vfat3"]="vfat3 v1.0.1";
   this->loadModule("vfat3","vfat3 v1.0.1");
 }
 

--- a/xhalcore/src/common/rpc_manager/vfat3.cpp
+++ b/xhalcore/src/common/rpc_manager/vfat3.cpp
@@ -32,9 +32,8 @@ uint32_t xhal::rpc::VFAT3::configureVFAT3DacMonitor(uint32_t ohN, uint32_t vfatM
     req.set_word("vfatMask",vfatMask);
     req.set_word("dacSelect",dacSelect);
 
-    wisc::RPCSvc* rpc_loc = getRPCptr();
     try {
-        rsp = rpc_loc->call_method(req);
+        rsp = rpc.call_method(req);
     }
     STANDARD_CATCH;
 
@@ -52,9 +51,8 @@ uint32_t xhal::rpc::VFAT3::configureVFAT3DacMonitorMultiLink(uint32_t ohMask, ui
     req.set_word_array("ohVfatMaskArray",ohVfatMaskArray,12);
     req.set_word("dacSelect",dacSelect);
 
-    wisc::RPCSvc* rpc_loc = getRPCptr();
     try {
-        rsp = rpc_loc->call_method(req);
+        rsp = rpc.call_method(req);
     }
     STANDARD_CATCH;
 
@@ -100,9 +98,8 @@ uint32_t xhal::rpc::VFAT3::readVFAT3ADC(uint32_t ohN, uint32_t *adcData, bool us
     req.set_word("useExtRefADC", useExtRefADC);
     req.set_word("vfatMask",vfatMask);
 
-    wisc::RPCSvc* rpc_loc = getRPCptr();
     try {
-        rsp = rpc_loc->call_method(req);
+        rsp = rpc.call_method(req);
     }
     STANDARD_CATCH;
 
@@ -130,9 +127,8 @@ uint32_t xhal::rpc::VFAT3::readVFAT3ADCMultiLink(uint32_t ohMask, uint32_t *ohVf
     req.set_word_array("ohVfatMaskArray",ohVfatMaskArray, 12);
     req.set_word("useExtRefADC", useExtRefADC);
 
-    wisc::RPCSvc* rpc_loc = getRPCptr();
     try {
-        rsp = rpc_loc->call_method(req);
+        rsp = rpc.call_method(req);
     }
     STANDARD_CATCH;
 

--- a/xhalcore/src/common/utils/XHALXMLParser.cpp
+++ b/xhalcore/src/common/utils/XHALXMLParser.cpp
@@ -55,7 +55,7 @@ void xhal::utils::XHALXMLParser::parseXML()
     ERROR("Error during Xerces-c Initialization." << std::endl
           << "  Exception message:"
           << xercesc::XMLString::transcode(toCatch.getMessage()));
-    throw xhal::utils::XHALXMLParserException("XHALParser: initialization failed"); 
+    throw xhal::utils::XHALXMLParserException("XHALParser: initialization failed");
     return;
   }
 
@@ -124,7 +124,7 @@ void xhal::utils::XHALXMLParser::parseXML()
     makeTree(m_root,"",0x0,m_nodes,NULL,m_vars,false);
     DEBUG("Number of nodes: " << m_nodes->size());
   } else{
-    throw xhal::utils::XHALXMLParserException("XHALParser: an error occured during parsing"); 
+    throw xhal::utils::XHALXMLParserException("XHALParser: an error occured during parsing");
   }
   DEBUG("Parsing done!");
   if (parser) parser->release();
@@ -169,7 +169,7 @@ void xhal::utils::XHALXMLParser::makeTree(xercesc::DOMNode * node, std::string b
   address = baseAddress;
   if (baseName != "") {name += ".";}
   if (auto tmp = getAttVal(node, "id"))
-  { 
+  {
     name.append(*tmp);
   } else {
     ERROR("getAttVal returned NONE, node has no id attribute");
@@ -179,11 +179,11 @@ void xhal::utils::XHALXMLParser::makeTree(xercesc::DOMNode * node, std::string b
   DEBUG("Node name: " << name);
   newNode.name = name;
   if (auto tmp = getAttVal(node, "description"))
-  { 
+  {
     newNode.description = *tmp;
   }
   if (auto tmp = getAttVal(node, "address"))
-  { 
+  {
     address = baseAddress + parseInt(*tmp);
     newNode.address = address;
     newNode.real_address = (address<<2)+0x64000000;
@@ -191,20 +191,20 @@ void xhal::utils::XHALXMLParser::makeTree(xercesc::DOMNode * node, std::string b
     TRACE("getAttVal returned NONE");
   }
   if (auto tmp = getAttVal(node, "permission"))
-  { 
+  {
     newNode.permission = *tmp;
   }
   if (auto tmp = getAttVal(node, "mask"))
-  { 
+  {
     newNode.mask = parseInt(*tmp);
   }
   newNode.isModule = (getAttVal(node, "fw_is_module")) && (*getAttVal(node, "fw_is_module") == "true");
   if (auto tmp = getAttVal(node, "sw_monitor_warn_min_threshold"))
-  { 
+  {
     newNode.warn_min_value = parseInt(*tmp);
   }
   if (auto tmp = getAttVal(node, "sw_monitor_error_min_threshold"))
-  { 
+  {
     newNode.warn_min_value = parseInt(*tmp);
   }
 
@@ -219,10 +219,10 @@ void xhal::utils::XHALXMLParser::makeTree(xercesc::DOMNode * node, std::string b
   xercesc::DOMNodeList *children_ = node->getChildNodes();
   const XMLSize_t nodeCount = children_->getLength();
   DEBUG("Node children length: " << nodeCount);
-          
+
   for( XMLSize_t ix = 0 ; ix < nodeCount ; ++ix )
   {
-    if (children_->item(ix)->getNodeType() == xercesc::DOMNode::ELEMENT_NODE) 
+    if (children_->item(ix)->getNodeType() == xercesc::DOMNode::ELEMENT_NODE)
     {
       makeTree(children_->item(ix),name,address,nodes,&newNode,vars,false);
     } else {
@@ -231,14 +231,18 @@ void xhal::utils::XHALXMLParser::makeTree(xercesc::DOMNode * node, std::string b
   }
 }
 
+#ifdef __ARM_ARCH_7A__
+std::experimental::optional<std::string> getAttVal(xercesc::DOMNode * t_node, const char * attname)
+#else
 boost::optional<std::string> xhal::utils::XHALXMLParser::getAttVal(xercesc::DOMNode * t_node_, const char * attname)
+#endif
 {
   TRACE("Call getAttVal for attribute " << attname);
   XMLCh * tmp = xercesc::XMLString::transcode(attname);
   xercesc::DOMElement* t_node = static_cast<xercesc::DOMElement*>(t_node_);
   TRACE("tmp: " << tmp);
   TRACE("successfull call of getAttribute: " << t_node->getAttribute(tmp));
-  char * tmp2 = xercesc::XMLString::transcode(t_node->getAttribute(tmp)); 
+  char * tmp2 = xercesc::XMLString::transcode(t_node->getAttribute(tmp));
   TRACE("tmp2: " << tmp2);
   if (tmp2[0]!='\0')
   {
@@ -247,7 +251,7 @@ boost::optional<std::string> xhal::utils::XHALXMLParser::getAttVal(xercesc::DOMN
     xercesc::XMLString::release(&tmp2);
     TRACE("result " << value);
     return value;
-  } else 
+  } else
   {
     TRACE("Attribute not found");
     xercesc::XMLString::release(&tmp);
@@ -303,8 +307,11 @@ std::string xhal::utils::XHALXMLParser::replaceAll( std::string const& original,
     return results;
 }
 
-//std::experimental::optional<xhal::utils::Node> xhal::utils::XHALXMLParser::getNode(const char* nodeName)
+#ifdef __ARM_ARCH_7A__
+std::experimental::optional<xhal::utils::Node> xhal::utils::XHALXMLParser::getNode(const char* nodeName)
+#else
 boost::optional<xhal::utils::Node> xhal::utils::XHALXMLParser::getNode(const char* nodeName)
+#endif
 {
   DEBUG("Call getNode for argument " << nodeName);
   //Node * res = NULL;
@@ -319,18 +326,22 @@ boost::optional<xhal::utils::Node> xhal::utils::XHALXMLParser::getNode(const cha
 }
 
 // Not used a.t.m. Do we need it? FIXME
+#ifdef __ARM_ARCH_7A__
+std::experimental::optional<xhal::utils::Node> getNodeFromAddress(const uint32_t nodeAddress)
+#else
 boost::optional<xhal::utils::Node> xhal::utils::XHALXMLParser::getNodeFromAddress(const uint32_t nodeAddress)
+#endif
 {
   //Node * res = NULL;
   //for (auto & n: *m_nodes)
   //{
-  //  if (nodeAddress == n.real_address) 
+  //  if (nodeAddress == n.real_address)
   //  {
   //    res = &n;
   //    break;
   //  }
   //}
-  //if (res) 
+  //if (res)
   //{
   //  return *res;
   //} else {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Exposes xhal classes to python.

Supporting changes:
- `XHALInterface` now has a public member function for returning the network alias of the AMC `getBoardName()`,
- `XHALInterface` and all inheriting classes will now store RPC modules that are to be loaded in `m_map_modName_modVer` 
- `XHALInterface` now has a public member function for (re-)loading all RPC modules which have been stored in `m_map_modName_modVer`.  Very useful for (re-)connecting.
- `XHALDevice` will now make use of inherited data member `m_map_modName_modVer` and inherited function `loadStoredModules` when (re-)connecting.
- New class `AMC` inheriting from `XHALDevice` defined in `amc.h` and `amc.cpp` in relevant locations.
  - Allows for getting VFAT mask for one or multiple links using corresponding CTP7 modules.
  - Allows for SBIT readout of a single OH using corresponding CTP7 module
- Added new utility structures for significantly reducing argument bloat in calibration scans:
   - `xhal::ParamScan` for providing scan parameters,
   - `xhal::ParamCalPulse` for providing calibration pulse parameters,
   - `xhal::ParamTtcGen` for providing configuration for the TTC Generator.
   - Defined in `../xhal/utils/CalParamTypes.h`
- Added new C++ types that will be exposed to python:
   - `PyDictUint32` is a typedef for `std::map<T, uint32_t>` where `T` is a template,
   - `PyDictVecUint32` is a typedef for `std::map<T, PyListUint32> where `T` is a template
       - Note:  `PyListUint32` is already defined and is of type `std::vector<uint32_t>`
   - `NestedPyDict` is a typedef for `std::map<T,M>` for T & M templates and M is typically itself an instance of `std::map<T,M>`, etc...
   - Defined in `../xhal/utils/PyTypes.h`
- Calibration routines now take as argument one or more Param structures as arguments.
- Calibration routines will no longer return an integer to be interpreted as an exit code but return sensible types (e.g. objects defined in `PyTypes.h` or void) and raise exceptions instead; additionally taking messy pointers to arrays as inputs has been dropped.
- `DaqMonitor` class has a new public method `getmonOHSCAmain` for returning SCA monitored temperatures and voltages for multiple OH links.
- Scan related methods of `Optohybrid` class will now take as input an instance of `xhal::ParamScan` to avoid argument bloat.
- Methods of `Optohybrid` class will no longer return an integer to be interpreted as an exit code but return sensible types (e.g. objects defined in `PyTypes.h` or void) and raise exceptions instead; additionally taking messy pointers to arrays as inputs has been dropped 
- Provided new methods to `VFAT3` class for DAC monitoring with the VFAT3 ADC.
- Methods of `VFAT3` class will no longer return an integer to be interpreted as an exit code but return sensible types (e.g. objects defined in `PyTypes.h` or void) and raise exceptions instead
- Added compiler preinstructions to be architecture safe when trying to expose `XHALXMLParser` to python.
 
Supercedes: https://github.com/cms-gem-daq-project/xhal/pull/87

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
Exposing the C++ API to python to improve ease of use and reduce complexity.

Additionally now functions/class methods return sensible types and raise exceptions (breaking change).  To limit argument bloat scan related functions/class methods take struct's which specify a set of parameters.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Testing is being passed to several students in the lab and would like to get this merged in so they can compartmentalise tests and submit follow-up bug reports (PR patches).

### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
