### PR TITLE
Fixing logging issues, adding exceptions forwarding and re(dis)connect methods

### DIFF
--- a/xhalcore/Makefile
+++ b/xhalcore/Makefile
@@ -20,7 +20,7 @@ include $(BUILD_HOME)/$(Project)/config/mfRPMRules.mk
 CCFLAGS=-O0 -g3 -fno-inline -Wall -fPIC -pthread -m64
 ADDFLAGS=-std=c++11
 
-IncludeDirs= /opt/xdaq/include
+IncludeDirs+= /opt/xdaq/include
 IncludeDirs+= /opt/rh/devtoolset-6/root/usr/include
 IncludeDirs+= ${BUILD_HOME}/${Project}/${LongPackage}/include
 INC=$(IncludeDirs:%=-I%)

--- a/xhalcore/include/xhal/XHALDevice.h
+++ b/xhalcore/include/xhal/XHALDevice.h
@@ -30,6 +30,12 @@ namespace xhal {
        * @param address_table_filename XML address table file name
        */
       XHALDevice(const std::string& board_domain_name, const std::string& address_table_filename);
+      virtual ~XHALDevice(){}
+
+      /**
+       * @brief Reconnect to RPC service and reload required modules
+       */
+      virtual void reconnect();
 
       /**
        * @brief read FW register by its name

--- a/xhalcore/include/xhal/XHALInterface.h
+++ b/xhalcore/include/xhal/XHALInterface.h
@@ -30,25 +30,25 @@
 #define STANDARD_CATCH \
 	catch (wisc::RPCSvc::NotConnectedException &e) { \
 		ERROR("Caught NotConnectedException: " << e.message.c_str()); \
-    throw xhal::utils::Exception(strcat("RPC NotConnectedException: ", e.message.c_str()));\
+    throw xhal::utils::XHALRPCNotConnectedException("RPC NotConnectedException: " + e.message);\
 	} \
 	catch (wisc::RPCSvc::RPCErrorException &e) { \
 		ERROR("Caught RPCErrorException: " << e.message.c_str()); \
-    throw xhal::utils::Exception(strcat("RPC ErrorException: ", e.message.c_str()));\
+    throw xhal::utils::XHALRPCException("RPC ErrorException: " + e.message);\
 	} \
 	catch (wisc::RPCSvc::RPCException &e) { \
 		ERROR("Caught exception: " << e.message.c_str()); \
-    throw xhal::utils::Exception(strcat("RPC exception: ", e.message.c_str()));\
+    throw xhal::utils::XHALRPCException("RPC exception: " + e.message);\
 	} \
   catch (wisc::RPCMsg::BadKeyException &e) { \
     ERROR("Caught exception: " << e.key.c_str()); \
-    throw xhal::utils::Exception(strcat("RPC BadKeyException (most probably remote register not accessible): ", e.key.c_str()));\
+    throw xhal::utils::XHALRPCException("RPC BadKeyException (most probably remote register not accessible): " + e.key);\
 	} 
 
 #define ASSERT(x) do { \
 		if (!(x)) { \
 			printf("Assertion Failed on line %u: %s\n", __LINE__, #x); \
-      throw xhal::utils::Exception("ASSERT failure");\
+      throw xhal::utils::XHALException("ASSERT failure");\
 		} \
 	} while (0)
 
@@ -65,12 +65,23 @@ namespace xhal {
        * @param board_domain_name domain name of CTP7
        */
       XHALInterface(const std::string& board_domain_name);
-      ~XHALInterface();
+      virtual ~XHALInterface();
 
       /**
        * @brief Initialize interface and establish RPC service connection with CTP7
        */
       void connect();
+
+      /**
+       * @brief Reconnect to RPC service and reload required modules
+       */
+      inline virtual void reconnect(){this->connect();}
+
+      /**
+       * @brief Initialize interface and establish RPC service connection with CTP7
+       */
+      void disconnect();
+
       /**
        * @brief load remote module
        */
@@ -92,6 +103,8 @@ namespace xhal {
       log4cplus::Logger m_logger;
       wisc::RPCSvc rpc;
       wisc::RPCMsg req, rsp;
+      bool isConnected;
+      static int index;
   };
 }
 #endif  // XHALINTERFACE_H

--- a/xhalcore/include/xhal/utils/Exception.h
+++ b/xhalcore/include/xhal/utils/Exception.h
@@ -11,26 +11,26 @@
 
 #include <string>
 #include <exception>
+#include <assert.h>
 
 #define XHAL_UTILS_DEFINE_EXCEPTION(EXCEPTION_NAME)                      \
 namespace xhal {                                                         \
   namespace utils {                                                      \
     class EXCEPTION_NAME : public std::exception {                       \
       public:                                                            \
-        EXCEPTION_NAME(const char* message) : m(message) {               \
+        EXCEPTION_NAME(std::string message) : msg(message) {             \
                                                                          \
         }                                                                \
                                                                          \
-        virtual ~EXCEPTION_NAME() throw() {                              \
+        virtual ~EXCEPTION_NAME() {                                      \
                                                                          \
         }                                                                \
                                                                          \
-        virtual const char* what() const throw() {                       \
-            return m.c_str();                                            \
+        virtual const char* what() {                                     \
+            return msg.c_str();                                          \
         }                                                                \
                                                                          \
-      protected:                                                         \
-        std::string m;                                                   \
+        std::string msg;                                                 \
                                                                          \
       private:                                                           \
         EXCEPTION_NAME();                                                \
@@ -38,6 +38,11 @@ namespace xhal {                                                         \
   } /* namespace xhal::utils */                                          \
 } /* namespace xhal */                                                   
 
-XHAL_UTILS_DEFINE_EXCEPTION(Exception)
+
+
+XHAL_UTILS_DEFINE_EXCEPTION(XHALException)
+XHAL_UTILS_DEFINE_EXCEPTION(XHALXMLParserException)
+XHAL_UTILS_DEFINE_EXCEPTION(XHALRPCException)
+XHAL_UTILS_DEFINE_EXCEPTION(XHALRPCNotConnectedException)
 
 #endif //XHAL_UTILS_EXCEPTION_H

--- a/xhalcore/include/xhal/utils/XHALXMLParser.h
+++ b/xhalcore/include/xhal/utils/XHALXMLParser.h
@@ -99,6 +99,7 @@ namespace xhal {
         xercesc::DOMNode* m_root;
         xercesc::DOMNode* m_node;
         xercesc::DOMNodeList* children;
+        static int index;
     
         /**
          * @brief fills custom node object

--- a/xhalcore/src/common/XHALDevice.cpp
+++ b/xhalcore/src/common/XHALDevice.cpp
@@ -14,6 +14,18 @@ xhal::XHALDevice::XHALDevice(const std::string& board_domain_name, const std::st
   this->loadModule("extras","extras v1.0.1");
 }
 
+void xhal::XHALDevice::reconnect()
+{
+  if (!isConnected){
+    this->connect();
+    this->loadModule("memory","memory v1.0.1");
+    this->loadModule("extras","extras v1.0.1");
+  } else {
+    ERROR("Interface already connected. Reconnection failed");
+    throw xhal::utils::XHALRPCException("RPC exception: Interface already connected. Reconnection failed");
+  }
+}
+
 uint32_t xhal::XHALDevice::readReg(std::string regName)
 {
   if (auto t_node = m_parser->getNode(regName.c_str()))
@@ -30,7 +42,7 @@ uint32_t xhal::XHALDevice::readReg(std::string regName)
     if (rsp.get_key_exists("error"))
     {
       ERROR("RPC response returned error, readReg failed"); 
-      throw xhal::utils::Exception("Error during register access");
+      throw xhal::utils::XHALException("Error during register access");
     } else {
       try{
         ASSERT(rsp.get_word_array_size("data") == 1);
@@ -56,7 +68,7 @@ uint32_t xhal::XHALDevice::readReg(std::string regName)
     return result;
   } else {
     ERROR("Register not found in address table!");
-    throw xhal::utils::Exception(strcat("XHAL XML exception: can't find node", regName.c_str()));
+    throw xhal::utils::XHALXMLParserException(strcat("XHAL XML exception: can't find node", regName.c_str()));
   }
 }
 
@@ -74,7 +86,7 @@ uint32_t xhal::XHALDevice::readReg(uint32_t address)
   if (rsp.get_key_exists("error"))
   {
     ERROR("RPC response returned error, readReg failed"); 
-    throw xhal::utils::Exception("Error during register access");
+    throw xhal::utils::XHALException("Error during register access");
   } else {
     try{
       ASSERT(rsp.get_word_array_size("data") == 1);
@@ -114,7 +126,7 @@ void xhal::XHALDevice::writeReg(std::string regName, uint32_t value)
       if (rsp.get_key_exists("error"))
       {
         ERROR("RPC response returned error, writeReg failed"); 
-        throw xhal::utils::Exception("Error during register access");
+        throw xhal::utils::XHALException("Error during register access");
       }
     } else {
       uint32_t current_val = this->readReg(m_node.real_address);
@@ -142,12 +154,12 @@ void xhal::XHALDevice::writeReg(std::string regName, uint32_t value)
       if (rsp.get_key_exists("error"))
       {
         ERROR("RPC response returned error, writeReg failed"); 
-        throw xhal::utils::Exception("Error during register access");
+        throw xhal::utils::XHALException("Error during register access");
       }
     }
   } else {
     ERROR("Register not found in address table!");
-    throw xhal::utils::Exception(strcat("XHAL XML exception: can't find node", regName.c_str()));
+    throw xhal::utils::XHALXMLParserException(strcat("XHAL XML exception: can't find node", regName.c_str()));
   }
 }
 

--- a/xhalcore/src/common/XHALInterface.cpp
+++ b/xhalcore/src/common/XHALInterface.cpp
@@ -31,7 +31,7 @@ void xhal::XHALInterface::connect()
   try {
     rpc.connect(m_board_domain_name);
     isConnected = true;
-    INFO("RPC disconnected");
+    INFO("RPC connected");
   }
   catch (wisc::RPCSvc::ConnectionFailedException &e) {
     ERROR("Caught RPCErrorException: " << e.message.c_str());
@@ -47,6 +47,7 @@ void xhal::XHALInterface::disconnect()
 {
   try {
     rpc.disconnect();
+    INFO("RPC disconnected");
     isConnected = false;
   }
   catch (wisc::RPCSvc::NotConnectedException &e) {

--- a/xhalcore/src/common/XHALInterface.cpp
+++ b/xhalcore/src/common/XHALInterface.cpp
@@ -1,13 +1,17 @@
 #include "xhal/XHALInterface.h"
 
+int xhal::XHALInterface::index = 0;
+
 xhal::XHALInterface::XHALInterface(const std::string& board_domain_name):
-  m_board_domain_name(board_domain_name)
+  m_board_domain_name(board_domain_name),
+  isConnected(false)
 {
   log4cplus::SharedAppenderPtr myAppender(new log4cplus::ConsoleAppender());
   std::auto_ptr<log4cplus::Layout> myLayout = std::auto_ptr<log4cplus::Layout>(new log4cplus::TTCCLayout());
   myAppender->setLayout( myLayout );
   // Following strange construction is required because it looks like log4cplus was compiled withot c++11 support...
-  auto t_logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("XHALInterface"));
+  auto t_logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("XHALInterface_"+m_board_domain_name + "_" + std::to_string(index)));
+  ++index;
   m_logger = t_logger;
   m_logger.addAppender(myAppender);
   m_logger.setLogLevel(log4cplus::INFO_LOG_LEVEL);
@@ -18,6 +22,7 @@ xhal::XHALInterface::XHALInterface(const std::string& board_domain_name):
 
 xhal::XHALInterface::~XHALInterface()
 {
+  this->disconnect();
   m_logger.shutdown();
 }
 
@@ -25,14 +30,31 @@ void xhal::XHALInterface::connect()
 {
   try {
     rpc.connect(m_board_domain_name);
+    isConnected = true;
+    INFO("RPC disconnected");
   }
   catch (wisc::RPCSvc::ConnectionFailedException &e) {
     ERROR("Caught RPCErrorException: " << e.message.c_str());
-    throw xhal::utils::Exception(strcat("RPC ConnectionFailedException: ",e.message.c_str()));
+    throw xhal::utils::XHALRPCException("RPC ConnectionFailedException: " + e.message);
   }
   catch (wisc::RPCSvc::RPCException &e) {
     ERROR("Caught exception: " << e.message.c_str());
-    throw xhal::utils::Exception(strcat("RPC exception: ",e.message.c_str()));
+    throw xhal::utils::XHALRPCException("RPC exception: " + e.message);
+  }
+}
+
+void xhal::XHALInterface::disconnect()
+{
+  try {
+    rpc.disconnect();
+    isConnected = false;
+  }
+  catch (wisc::RPCSvc::NotConnectedException &e) {
+    INFO("Caught RPCNotConnectedException: " << e.message.c_str());
+  }
+  catch (wisc::RPCSvc::RPCException &e) {
+    ERROR("Caught exception: " << e.message.c_str());
+    throw xhal::utils::XHALRPCException("RPC exception: " + e.message);
   }
 }
 

--- a/xhalcore/src/common/python_wrappers/XHALInterface_python.cpp
+++ b/xhalcore/src/common/python_wrappers/XHALInterface_python.cpp
@@ -1,9 +1,45 @@
 #include <boost/python.hpp>
+#include "xhal/utils/Exception.h"
 #include "xhal/XHALDevice.h"
 #include "xhal/utils/PyTypes.h"
 #include "xhal/rpc/daq_monitor.h"
 #include <boost/python/suite/indexing/vector_indexing_suite.hpp>
 #include <boost/python/suite/indexing/map_indexing_suite.hpp>
+
+// Boost Python exception translators
+
+//https://stackoverflow.com/questions/9620268/boost-python-custom-exception-class
+PyObject* createExceptionClass(const char* name, PyObject* baseTypeObj = PyExc_Exception)
+{
+    using std::string;
+    namespace bp = boost::python;
+
+    string scopeName = bp::extract<string>(bp::scope().attr("__name__"));
+    string qualifiedName0 = scopeName + "." + name;
+    char* qualifiedName1 = const_cast<char*>(qualifiedName0.c_str());
+
+    PyObject* typeObj = PyErr_NewException(qualifiedName1, baseTypeObj, 0);
+    if(!typeObj) bp::throw_error_already_set();
+    bp::scope().attr(name) = bp::handle<>(bp::borrowed(typeObj));
+    return typeObj;
+}
+
+// https://www.boost.org/doc/libs/1_51_0/libs/python/doc/tutorial/doc/html/python/exception.html
+#ifndef PY_EXCEPTION_TRANSLATOR
+#define PY_EXCEPTION_TRANSLATOR(TRANSLATOR_NAME,EXCEPTION_NAME,EXCEPTION_OBJ)        \
+PyObject* EXCEPTION_OBJ = NULL;                                                      \
+inline void TRANSLATOR_NAME(EXCEPTION_NAME const& e)                                 \
+{                                                                                    \
+  assert(EXCEPTION_OBJ != NULL);                                                     \
+  /* Use the Python 'C' API to set up an exception object*/                          \
+  PyErr_SetString(EXCEPTION_OBJ, e.msg.c_str());                                     \
+}                                                                    
+#endif
+
+PY_EXCEPTION_TRANSLATOR(translate_XHALException,xhal::utils::XHALException, obj_XHALException)
+PY_EXCEPTION_TRANSLATOR(translate_XHALXMLParserException,xhal::utils::XHALXMLParserException, obj_XHALXMLParserException)
+PY_EXCEPTION_TRANSLATOR(translate_XHALRPCException,xhal::utils::XHALRPCException, obj_XHALRPCException)
+PY_EXCEPTION_TRANSLATOR(translate_XHALRPCNotConnectedException,xhal::utils::XHALRPCNotConnectedException, obj_XHALRPCNotConnectedException)
 
 // https://stackoverflow.com/questions/7577410/boost-python-select-between-overloaded-methods
 uint32_t (xhal::XHALDevice::*readReg_byname)(std::string regName) = &xhal::XHALDevice::readReg;
@@ -16,9 +52,21 @@ BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(getmonOHmain_overloads, getmonOHmain, 0, 
 
 BOOST_PYTHON_MODULE(xhalpy){
   using namespace boost::python;
+  
+  obj_XHALException = createExceptionClass("XHALException");
+  obj_XHALXMLParserException = createExceptionClass("XHALXMLParserException");
+  obj_XHALRPCException = createExceptionClass("XHALRPCException");
+  obj_XHALRPCNotConnectedException = createExceptionClass("XHALRPCNotConnectedException");
+
+  register_exception_translator<xhal::utils::XHALException>(&translate_XHALException);
+  register_exception_translator<xhal::utils::XHALXMLParserException>(&translate_XHALXMLParserException);
+  register_exception_translator<xhal::utils::XHALRPCException>(&translate_XHALRPCException);
+  register_exception_translator<xhal::utils::XHALRPCNotConnectedException>(&translate_XHALRPCNotConnectedException);
 
   class_<xhal::XHALDevice>("XHALDevice", init<const std::string&, const std::string&>())
     .def("connect",&xhal::XHALDevice::connect)
+    .def("reconnect",&xhal::XHALDevice::reconnect)
+    .def("disconnect",&xhal::XHALDevice::disconnect)
     .def("loadModule",&xhal::XHALDevice::loadModule)
     .def("setLogLevel",&xhal::XHALDevice::setLogLevel)
     .def("readReg",readReg_byname)

--- a/xhalcore/src/common/rpc_manager/daq_monitor.cpp
+++ b/xhalcore/src/common/rpc_manager/daq_monitor.cpp
@@ -43,7 +43,7 @@ PyListUint32 xhal::rpc::DaqMonitor::getmonTRIGGERmain(uint32_t noh)
         } else {
             std::string t;
             result.push_back(rsp.get_word("OR_TRIGGER_RATE"));
-            for (int i = 0; i < noh; i++) {
+            for (unsigned int i = 0; i < noh; i++) {
                 t = "OH"+std::to_string(i)+".TRIGGER_RATE";
                 result.push_back(rsp.get_word(t));
             }
@@ -69,7 +69,7 @@ PyListUint32 xhal::rpc::DaqMonitor::getmonTRIGGEROHmain(uint32_t noh)
             // FIXME raise an exception
         }else {
             std::string t;
-            for (int i = 0; i < noh; i++) {
+            for (unsigned int i = 0; i < noh; i++) {
                 t = "OH"+std::to_string(i)+".LINK0_MISSED_COMMA_CNT";
                 result[i] = rsp.get_word(t);
                 t = "OH"+std::to_string(i)+".LINK1_MISSED_COMMA_CNT";
@@ -138,7 +138,7 @@ PyListUint32 xhal::rpc::DaqMonitor::getmonDAQOHmain(uint32_t noh)
             // FIXME raise an exception
         }else {
             std::string t;
-            for (int i = 0; i < noh; i++) {
+            for (unsigned int i = 0; i < noh; i++) {
                 t = "OH"+std::to_string(i)+".STATUS.EVT_SIZE_ERR";
                 result[i] = rsp.get_word(t);
                 t = "OH"+std::to_string(i)+".STATUS.EVENT_FIFO_HAD_OFLOW";
@@ -174,7 +174,7 @@ PyListUint32 xhal::rpc::DaqMonitor::getmonOHmain(uint32_t noh)
             // FIXME raise an exception
         } else {
             std::string t;
-            for (int i = 0; i < noh; i++) {
+            for (unsigned int i = 0; i < noh; i++) {
                 t = "OH"+std::to_string(i)+".FW_VERSION";
                 result[i] = rsp.get_word(t);
                 t = "OH"+std::to_string(i)+".EVENT_COUNTER";

--- a/xhalcore/src/common/utils/XHALXMLParser.cpp
+++ b/xhalcore/src/common/utils/XHALXMLParser.cpp
@@ -1,12 +1,15 @@
 #include "xhal/utils/XHALXMLParser.h"
 
+int xhal::utils::XHALXMLParser::index = 0;
+
 xhal::utils::XHALXMLParser::XHALXMLParser(const std::string& xmlFile)
 {
   m_xmlFile = xmlFile;
   log4cplus::SharedAppenderPtr myAppender(new log4cplus::ConsoleAppender());
   std::auto_ptr<log4cplus::Layout> myLayout = std::auto_ptr<log4cplus::Layout>(new log4cplus::TTCCLayout());
   myAppender->setLayout( myLayout );
-  auto t_logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("XHALXMLParser"));
+  auto t_logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("XHALXMLParser_" + std::to_string(index)));
+  ++index;
   m_logger = t_logger;
   m_logger.addAppender(myAppender);
   m_logger.setLogLevel(log4cplus::INFO_LOG_LEVEL);
@@ -52,7 +55,7 @@ void xhal::utils::XHALXMLParser::parseXML()
     ERROR("Error during Xerces-c Initialization." << std::endl
           << "  Exception message:"
           << xercesc::XMLString::transcode(toCatch.getMessage()));
-    throw xhal::utils::Exception("XHALParser: initialization failed"); 
+    throw xhal::utils::XHALXMLParserException("XHALParser: initialization failed"); 
     return;
   }
 
@@ -121,7 +124,7 @@ void xhal::utils::XHALXMLParser::parseXML()
     makeTree(m_root,"",0x0,m_nodes,NULL,m_vars,false);
     DEBUG("Number of nodes: " << m_nodes->size());
   } else{
-    throw xhal::utils::Exception("XHALParser: an error occured during parsing"); 
+    throw xhal::utils::XHALXMLParserException("XHALParser: an error occured during parsing"); 
   }
   DEBUG("Parsing done!");
   if (parser) parser->release();

--- a/xhalcore/test/test.py
+++ b/xhalcore/test/test.py
@@ -8,6 +8,9 @@ def w1(str):
 
 print os.getpid()
 #w1('starting main..press a key')
+def test_log_dups():
+  eagle64_1=xi.XHALDevice("eagle64","/opt/cmsgemos/etc/maps/amc_address_table_top.xml")
+  eagle64_2=xi.XHALDevice("eagle64","/opt/cmsgemos/etc/maps/amc_address_table_top.xml")
 def test_xhaldevice():
   print "TEST OF XHALDEVICE WRAPPER"
   eagle64=xi.XHALDevice("eagle64","/opt/cmsgemos/etc/maps/amc_address_table_top.xml")
@@ -60,6 +63,33 @@ def test_xhalDaqMon():
   print "\n"
   return
 
+def test_xhalrpc_exception():
+  print "TEST OF XHAL RPC EXCEPTIONS HANDLING"
+  eagle64=xi.XHALDevice("eagle64","/opt/cmsgemos/etc/maps/amc_address_table_top.xml")
+  print "read reg by name: eagle64.readReg(GEM_AMC.GEM_SYSTEM.BOARD_ID)=%08x"%(eagle64.readReg("GEM_AMC.GEM_SYSTEM.BOARD_ID"))
+  print "Now disconnect"
+  eagle64.disconnect()
+  print "RPC service disconnected. Now try to read register by name again"
+  try:
+    print "read reg by name: eagle64.readReg(GEM_AMC.GEM_SYSTEM.BOARD_ID)=%08x"%(eagle64.readReg("GEM_AMC.GEM_SYSTEM.BOARD_ID"))
+  except xi.XHALRPCNotConnectedException as e:
+    print "Caught exception: %s" %(e)
+  print "Now reconnect"
+  eagle64.reconnect()
+  print "RPC service reconnected. Now try to read register by name again"
+  try:
+    print "read reg by name: eagle64.readReg(GEM_AMC.GEM_SYSTEM.BOARD_ID)=%08x"%(eagle64.readReg("GEM_AMC.GEM_SYSTEM.BOARD_ID"))
+  except xi.XHALRPCNotConnectedException as e:
+    print "Caught exception: %s" %(e)
+  print "Test reconnection attempt on connected service"
+  try:
+    eagle64.reconnect()
+  except xi.XHALRPCException as e:
+    print "Caught exception: %s" %(e)
+    
+
 test_xhaldevice()
 test_xhalDaqMon()
+test_xhalrpc_exception()
+test_log_dups()
 print "All tests are completed"


### PR DESCRIPTION
- Fixing loggin duplication
- adding `reconnect` method
- adding `disconnect` method
- adding exception forwarding to python

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Adding static counters to distinguish loggers
- Adding `reconnect` method to `XHALDevice` class, which will load all required modules. In case the interface is still connected, reconnection attempt will fail and corresponding exception raised.
- Adding `disconnect` method which clears RPC connection
- Providing python bindings for the following exception classes :
  * XHALException
  * XHALXMLParserException
  * XHALRPCException
  * XHALRPCNotConnectedException

Example code:
```python
import xhalpy as xi
print "TEST OF XHAL RPC EXCEPTIONS HANDLING"
eagle64=xi.XHALDevice("eagle64","/opt/cmsgemos/etc/maps/amc_address_table_top.xml")
print "read reg by name: eagle64.readReg(GEM_AMC.GEM_SYSTEM.BOARD_ID)=%08x"%(eagle64.readReg("GEM_AMC.GEM_SYSTEM.BOARD_ID"))
print "Now disconnect"
eagle64.disconnect()
print "RPC service disconnected. Now try to read register by name again"
try:
  print "read reg by name: eagle64.readReg(GEM_AMC.GEM_SYSTEM.BOARD_ID)=%08x"%(eagle64.readReg("GEM_AMC.GEM_SYSTEM.BOARD_ID"))
except xi.XHALRPCNotConnectedException as e:
  print "Caught exception: %s" %(e)
print "Now reconnect"
eagle64.reconnect()
print "RPC service reconnected. Now try to read register by name again"
try:
  print "read reg by name: eagle64.readReg(GEM_AMC.GEM_SYSTEM.BOARD_ID)=%08x"%(eagle64.readReg("GEM_AMC.GEM_SYSTEM.BOARD_ID"))
except xi.XHALRPCNotConnectedException as e:
  print "Caught exception: %s" %(e)
print "Test reconnection attempt on connected service"
try:
  eagle64.reconnect()
except xi.XHALRPCException as e:
  print "Caught exception: %s" %(e)
```
Expected output:
```bash
1 [140054805878592] INFO XHALInterface_eagle64_0 <> - XHAL Logger tuned up
5 [140054805878592] INFO XHALInterface_eagle64_0 <> - RPC connected
5 [140054805878592] INFO XHALInterface_eagle64_0 <> - XHAL Interface connected
10 [140054805878592] INFO XHALXMLParser_0 <> - Successfully initialized XML4C system
read reg by name: eagle64.readReg(GEM_AMC.GEM_SYSTEM.BOARD_ID)=0000beef
Now disconnect
2133 [140054805878592] INFO XHALInterface_eagle64_0 <> - RPC disconnected
RPC service disconnected. Now try to read register by name again
2133 [140054805878592] ERROR XHALInterface_eagle64_0 <> - Caught NotConnectedException: Not connected to rpc service
Caught exception: RPC NotConnectedException: Not connected to rpc service
Now reconnect
2137 [140054805878592] INFO XHALInterface_eagle64_0 <> - RPC connected
RPC service reconnected. Now try to read register by name again
read reg by name: eagle64.readReg(GEM_AMC.GEM_SYSTEM.BOARD_ID)=0000beef
Test reconnection attempt on connected service
2476 [140054805878592] ERROR XHALInterface_eagle64_0 <> - Interface already connected. Reconnection failed
Caught exception: RPC exception: Interface already connected. Reconnection failed
2476 [140054805878592] INFO XHALInterface_eagle64_0 <> - RPC disconnected
```


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested with (updated) testing script
### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->