### PR TITLE
Cleanup build, package ARM libs in devel RPM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,12 +3,16 @@ SUBPACKAGES := \
 	xhalarm \
         xhalcore
 
-SUBPACKAGES.DEBUG    := $(patsubst %,%.debug,    ${SUBPACKAGES})
-SUBPACKAGES.RPM      := $(patsubst %,%.rpm,      ${SUBPACKAGES})
-SUBPACKAGES.DOC      := $(patsubst %,%.doc,      ${SUBPACKAGES})
-SUBPACKAGES.CLEANRPM := $(patsubst %,%.cleanrpm, ${SUBPACKAGES})
-SUBPACKAGES.CLEANDOC := $(patsubst %,%.cleandoc,    ${SUBPACKAGES})
-SUBPACKAGES.CLEAN    := $(patsubst %,%.clean,    ${SUBPACKAGES})
+SUBPACKAGES.DEBUG    := $(patsubst %,%.debug,    $(SUBPACKAGES))
+SUBPACKAGES.RPM      := $(patsubst %,%.rpm,      $(SUBPACKAGES))
+SUBPACKAGES.DOC      := $(patsubst %,%.doc,      $(SUBPACKAGES))
+SUBPACKAGES.CLEANRPM := $(patsubst %,%.cleanrpm, $(SUBPACKAGES))
+SUBPACKAGES.CLEANDOC := $(patsubst %,%.cleandoc, $(SUBPACKAGES))
+SUBPACKAGES.CLEAN    := $(patsubst %,%.clean,    $(SUBPACKAGES))
+
+.PHONY: build clean cleanall cleandoc cleanrpm
+
+build: $(SUBPACKAGES)
 
 all: $(SUBPACKAGES) $(SUBPACKAGES.RPM) $(SUBPACKAGES.DOC)
 
@@ -20,12 +24,14 @@ cleanrpm: $(SUBPACKAGES.CLEANRPM)
 
 cleandoc: $(SUBPACKAGES.CLEANDOC)
 
-clean: $(SUBPACKAGES.CLEAN) $(SUBPACKAGES.CLEANRPM) $(SUBPACKAGES.CLEANDOC) 
+clean: $(SUBPACKAGES.CLEAN)
+
+cleanall: clean cleandoc cleanrpm
 
 $(SUBPACKAGES):
 	$(MAKE) -C $@
 
-$(SUBPACKAGES.RPM):
+$(SUBPACKAGES.RPM): $(SUBPACKAGES)
 	$(MAKE) -C $(patsubst %.rpm,%, $@) rpm
 
 $(SUBPACKAGES.DOC):
@@ -40,10 +46,10 @@ $(SUBPACKAGES.CLEANDOC):
 $(SUBPACKAGES.CLEAN):
 	$(MAKE) -C $(patsubst %.clean,%, $@) clean
 
-# .PHONY: $(SUBPACKAGES) $(SUBPACKAGES.INSTALL) $(SUBPACKAGES.CLEAN)
+.PHONY: $(SUBPACKAGES) $(SUBPACKAGES.INSTALL) $(SUBPACKAGES.CLEAN) $(SUBPACKAGES.DOC) $(SUBPACKAGES.RPM) $(SUBPACKAGES.CLEANRPM) $(SUBPACKAGES.CLEANDOC)
 
-# python:
+python:
 
-# xhalarm:
+xhalarm:
 
-# xhalcore: xhalarm
+xhalcore: xhalarm

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SUBPACKAGES := \
         python \
-        xhalcore \
-	xhalarm
+	xhalarm \
+        xhalcore
 
 SUBPACKAGES.DEBUG    := $(patsubst %,%.debug,    ${SUBPACKAGES})
 SUBPACKAGES.RPM      := $(patsubst %,%.rpm,      ${SUBPACKAGES})
@@ -39,3 +39,11 @@ $(SUBPACKAGES.CLEANDOC):
 
 $(SUBPACKAGES.CLEAN):
 	$(MAKE) -C $(patsubst %.clean,%, $@) clean
+
+# .PHONY: $(SUBPACKAGES) $(SUBPACKAGES.INSTALL) $(SUBPACKAGES.CLEAN)
+
+# python:
+
+# xhalarm:
+
+# xhalcore: xhalarm

--- a/python/Makefile
+++ b/python/Makefile
@@ -1,12 +1,14 @@
 SUBPACKAGES := \
         reg_interface_gem \
 
-SUBPACKAGES.DEBUG    := $(patsubst %,%.debug,    ${SUBPACKAGES})
-SUBPACKAGES.DOC      := $(patsubst %,%.doc,      ${SUBPACKAGES})
-SUBPACKAGES.RPM      := $(patsubst %,%.rpm,      ${SUBPACKAGES})
-SUBPACKAGES.CLEANRPM := $(patsubst %,%.cleanrpm, ${SUBPACKAGES})
-SUBPACKAGES.CLEANDOC := $(patsubst %,%.cleandoc,    ${SUBPACKAGES})
-SUBPACKAGES.CLEAN    := $(patsubst %,%.clean,    ${SUBPACKAGES})
+SUBPACKAGES.DEBUG    := $(patsubst %,%.debug,    $(SUBPACKAGES))
+SUBPACKAGES.DOC      := $(patsubst %,%.doc,      $(SUBPACKAGES))
+SUBPACKAGES.RPM      := $(patsubst %,%.rpm,      $(SUBPACKAGES))
+SUBPACKAGES.CLEANRPM := $(patsubst %,%.cleanrpm, $(SUBPACKAGES))
+SUBPACKAGES.CLEANDOC := $(patsubst %,%.cleandoc, $(SUBPACKAGES))
+SUBPACKAGES.CLEAN    := $(patsubst %,%.clean,    $(SUBPACKAGES))
+
+.PHONY: $(SUBPACKAGES) $(SUBPACKAGES.INSTALL) $(SUBPACKAGES.CLEAN) $(SUBPACKAGES.DOC) $(SUBPACKAGES.RPM) $(SUBPACKAGES.CLEANRPM) $(SUBPACKAGES.CLEANDOC)
 
 rpm: $(SUBPACKAGES) $(SUBPACKAGES.RPM)
 

--- a/xhalarm/Makefile
+++ b/xhalarm/Makefile
@@ -19,52 +19,59 @@ include $(BUILD_HOME)/$(Project)/config/mfRPMRules.mk
 
 ADDFLAGS=-std=gnu++14
 
-IncludeDirs  = ${BUILD_HOME}/${Project}/xhalcore/include
+IncludeDirs = $(BUILD_HOME)/$(Project)/xhalcore/include
 INC=$(IncludeDirs:%=-I%)
 
 Libraries+= -llog4cplus -lxerces-c -lstdc++
-LIB=$(LibraryDirs)
-LIB+= $(Libraries)
 
-LDFLAGS= -shared
-SRCS_XHAL = $(shell echo ../xhalcore/src/common/utils/*.cpp)
-OBJS_XHAL = $(SRCS_XHAL:.cpp=.o)
+LDFLAGS+=-shared $(LibraryDirs)
 
-XHAL_LIB=${BUILD_HOME}/${Project}/${LongPackage}/lib/libxhal.so
+SrcLocation =$(BUILD_HOME)/$(Project)/xhalcore/src/common
+SRCS_XHAL   = $(shell echo $(SrcLocation)/utils/*.cpp)
+
+## Place object files in lib/linux?
+ObjLocation = src/linux/$(Arch)
+OBJS_XHAL   = $(patsubst $(SrcLocation)/%,$(ObjLocation)/%, $(SRCS_XHAL:.cpp=.o))
+
+XHAL_LIB=$(BUILD_HOME)/$(Project)/$(LongPackage)/lib/libxhal.so
 
 .PHONY: clean rpc prerpm
 
-default: clean
+default: build
 	@echo "Running default target"
 	$(MakeDir) $(PackageDir)
 
 _rpmprep: preprpm
 	@echo "Running _rpmprep target"
+
 preprpm: default
 	@echo "Running preprpm target"
 	@cp -rf lib $(PackageDir)
 
-build:${XHAL_LIB}
+build: clean $(XHAL_LIB)
 
-_all: clean ${XHAL_LIB} 
+_all: clean $(XHAL_LIB) 
 
 doc:
 	@echo "TO DO"
 
 $(XHAL_LIB): $(OBJS_XHAL) 
-	@mkdir -p ${BUILD_HOME}/${Project}/${LongPackage}/lib
-	$(CC) $(CFLAGS) $(ADDFLAGS) ${LDFLAGS} $(INC) $(LIB) -o $@ $^
+	@mkdir -p $(BUILD_HOME)/$(Project)/$(LongPackage)/lib
+	$(CC) $(ADDFLAGS) $(LDFLAGS) -o $@ $^ $(Libraries)
 
-$(OBJS_XHAL):$(SRCS_XHAL)
-	$(CC) $(CFLAGS) $(ADDFLAGS) $(INC) $(LIB) -c -o $@ $<
+$(OBJS_XHAL): $(SRCS_XHAL)
+	$(MakeDir) -p $(shell dirname $@)
+	$(CC) $(CFLAGS) $(ADDFLAGS) $(INC) -c -o $@ $<
 
 %.o: %.c
 	$(CC) -std=gnu99 -c $(CFLAGS) -o $@ $<
 %.o: %.cc
 	$(CXX) -std=c++0x -c $(CFLAGS) -o $@ $<
 
-clean: cleanrpm
-	-rm -rf ${XHAL_LIB} ${OBJS_XHAL}
+clean:
+	-rm -rf $(OBJS_XHAL)
+	-rm -rf $(XHAL_LIB)
+	-rm -rf $(BUILD_HOME)/$(Project)/$(LongPackage)/lib
 	-rm -rf $(PackageDir)
 
 cleandoc: 

--- a/xhalcore/Makefile
+++ b/xhalcore/Makefile
@@ -7,7 +7,7 @@ PackageName  := $(ShortPackage)
 PackagePath  := $(shell pwd)
 PackageDir   := pkg/$(ShortPackage)
 Packager     := Mykhailo Dalchenko
-#Arch         := x86_64
+Arch         := x86_64
 
 XHAL_VER_MAJOR:=$(shell $(BUILD_HOME)/$(Project)/config/tag2rel.sh | awk '{split($$0,a," "); print a[1];}' | awk '{split($$0,b,":"); print b[2];}')
 XHAL_VER_MINOR:=$(shell $(BUILD_HOME)/$(Project)/config/tag2rel.sh | awk '{split($$0,a," "); print a[2];}' | awk '{split($$0,b,":"); print b[2];}')
@@ -17,33 +17,36 @@ include $(BUILD_HOME)/$(Project)/config/mfCommonDefs.mk
 include $(BUILD_HOME)/$(Project)/config/mfPythonDefs.mk
 include $(BUILD_HOME)/$(Project)/config/mfRPMRules.mk
 
-CCFLAGS=-O0 -g3 -fno-inline -Wall -fPIC -pthread -m64
-ADDFLAGS=-std=c++11
+CCFLAGS=-O0 -g3 -fno-inline -Wall -pthread
+ADDFLAGS=-fPIC -std=c++11 -m64
 
 IncludeDirs+= /opt/xdaq/include
-# IncludeDirs+= /opt/rh/devtoolset-6/root/usr/include
-IncludeDirs+= ${BUILD_HOME}/${Project}/${LongPackage}/include
+IncludeDirs+= $(BUILD_HOME)/$(Project)/$(LongPackage)/include
 INC=$(IncludeDirs:%=-I%)
 
 Libraries+= -llog4cplus -lxerces-c -lwiscrpcsvc -lstdc++
+
 LibraryDirs+=-L/opt/xdaq/lib
 LibraryDirs+=-L/opt/wiscrpcsvc/lib
-LIB=$(LibraryDirs)
-LIB+= $(Libraries)
 
-LDFLAGS= -shared
-SRCS_UTILS = $(shell echo src/common/utils/*.cpp)
-SRCS_XHAL = $(shell echo src/common/*.cpp)
-SRCS_XHALPY = $(shell echo src/common/python_wrappers/*.cpp)
-OBJS_UTILS = $(SRCS_UTILS:.cpp=.o)
-OBJS_XHAL = $(SRCS_XHAL:.cpp=.o)
-OBJS_XHALPY = $(SRCS_XHALPY:.cpp=.o)
-SRCS_RPC_MAN = $(shell echo src/common/rpc_manager/*.cpp)
-OBJS_RPC_MAN = $(SRCS_RPC_MAN:.cpp=.o)
+LDFLAGS = -shared $(LibraryDirs)
 
-XHALCORE_LIB=${BUILD_HOME}/${Project}/${LongPackage}/lib/libxhal.so
-RPC_MAN_LIB=${BUILD_HOME}/${Project}/${LongPackage}/lib/librpcman.so
-XHALPY_LIB=${BUILD_HOME}/${Project}/${LongPackage}/lib/xhalpy.so
+SrcLocation  = src/common
+SRCS_UTILS   = $(shell echo $(SrcLocation)/utils/*.cpp)
+SRCS_XHAL    = $(shell echo $(SrcLocation)/*.cpp)
+SRCS_XHALPY  = $(shell echo $(SrcLocation)/python_wrappers/*.cpp)
+SRCS_RPC_MAN = $(shell echo $(SrcLocation)/rpc_manager/*.cpp)
+
+## Place object files in src/linux/$(Arch)
+ObjLocation = src/linux/$(Arch)
+OBJS_UTILS   = $(patsubst $(SrcLocation)/%,$(ObjLocation)/%, $(SRCS_UTILS:.cpp=.o))
+OBJS_XHAL    = $(patsubst $(SrcLocation)/%,$(ObjLocation)/%, $(SRCS_XHAL:.cpp=.o))
+OBJS_XHALPY  = $(patsubst $(SrcLocation)/%,$(ObjLocation)/%, $(SRCS_XHALPY:.cpp=.o))
+OBJS_RPC_MAN = $(patsubst $(SrcLocation)/%,$(ObjLocation)/%, $(SRCS_RPC_MAN:.cpp=.o))
+
+XHALCORE_LIB = $(BUILD_HOME)/$(Project)/$(LongPackage)/lib/libxhal.so
+RPC_MAN_LIB  = $(BUILD_HOME)/$(Project)/$(LongPackage)/lib/librpcman.so
+XHALPY_LIB   = $(BUILD_HOME)/$(Project)/$(LongPackage)/lib/xhalpy.so
 
 .PHONY: clean xhalcore rpc prerpm
 
@@ -56,46 +59,58 @@ _rpmprep: preprpm
 
 preprpm: default
 	@echo "Running preprpm target"
-	@cp -rf ../xhalarm/lib lib/arm
-	@cp -rf lib $(PackageDir)
+	$(MakeDir) lib/arm
+	@cp -rfp $(BUILD_HOME)/$(Project)/xhalarm/lib/*.so lib/arm
+	@cp -rfp lib $(PackageDir)
 
 build: xhalcore rpc
 
-_all:${XHALCORE_LIB} ${RPC_MAN_LIB} ${XHALPY_LIB}
+_all: $(XHALCORE_LIB) $(RPC_MAN_LIB) $(XHALPY_LIB)
 
-rpc:${RPC_MAN_LIB}
+rpc: xhalcore $(RPC_MAN_LIB)
 
-xhalcore:${XHALCORE_LIB}
+xhalcore: $(XHALCORE_LIB)
 
-xhalpy:${XHALPY_LIB}
+xhalpy: xhalcore rpc $(XHALPY_LIB)
 
 doc:
 	@echo "TO DO"
 
-$(XHALCORE_LIB): $(OBJS_UTILS) $(OBJS_XHAL)
-	@mkdir -p ${BUILD_HOME}/${Project}/${LongPackage}/lib/
-	$(CC) $(CCFLAGS) $(ADDFLAGS) ${LDFLAGS} $(INC) $(LIB) -o $@ $^
+$(OBJS_UTILS): $(SRCS_UTILS)
+	@rm -rf $(OBJS_UTILS)
+	$(MakeDir) $(shell dirname $@)
+	$(CC) $(CCFLAGS) $(ADDFLAGS) $(INC) -c $< -o $@
 
-$(OBJS_UTILS):$(SRCS_UTILS)
-	$(CC) $(CCFLAGS) $(ADDFLAGS) $(INC) $(LIB) -c -o $@ $<
+$(OBJS_XHAL): $(SRCS_XHAL)
+	$(MakeDir) $(shell dirname $@)
+#	$(CC) $(CCFLAGS) $(ADDFLAGS) $(INC) $(Libraries) -c $(@:%.o=%.cpp) -o $@ 
+	$(CC) $(CCFLAGS) $(ADDFLAGS) $(INC) -c -o $@ $(patsubst $(ObjLocation)/%,$(SrcLocation)/%, $(@:%.o=%.cpp))
 
-$(OBJS_XHAL):$(SRCS_XHAL)
-	$(CC) $(CCFLAGS) $(ADDFLAGS) $(INC) $(LIB) -c $(@:%.o=%.cpp) -o $@ 
-
-$(RPC_MAN_LIB): $(OBJS_RPC_MAN)
-	$(CC) $(CCFLAGS) $(ADDFLAGS) ${LDFLAGS} $(INC) $(LIB) -o $@ $^
-
-$(OBJS_RPC_MAN):$(SRCS_RPC_MAN)
-	$(CC) $(CCFLAGS) $(ADDFLAGS) $(INC) $(LIB) -c $(@:%.o=%.cpp) -o $@ 
-
-$(XHALPY_LIB):$(OBJS_XHALPY)
-	$(CC) $(CCFLAGS) ${LDFLAGS} $(ADDFLAGS) $(INC) $(LIB) -lboost_python -L$(PYTHON_LIB_PREFIX) -l$(PYTHON_LIB) -Llib/ -lxhal -lrpcman -o $@ $<
+$(OBJS_RPC_MAN): $(SRCS_RPC_MAN)
+	$(MakeDir) $(shell dirname $@)
+#	$(CC) $(CCFLAGS) $(ADDFLAGS) $(INC) $(Libraries) -c $(@:%.o=%.cpp) -o $@ 
+	$(CC) $(CCFLAGS) $(ADDFLAGS) $(INC) -c -o $@ $(patsubst $(ObjLocation)/%,$(SrcLocation)/%, $(@:%.o=%.cpp))
 
 $(OBJS_XHALPY):$(SRCS_XHALPY)
-	$(CC) $(CCFLAGS) $(ADDFLAGS) $(INC) -I$(PYTHON_INCLUDE_PREFIX) $(LIB) -c -o $@ $<
+	$(MakeDir) $(shell dirname $@)
+	$(CC) $(CCFLAGS) $(ADDFLAGS) $(INC) -I$(PYTHON_INCLUDE_PREFIX) -c $< -o $@
+
+$(XHALCORE_LIB): $(OBJS_UTILS) $(OBJS_XHAL)
+	$(MakeDir) $(BUILD_HOME)/$(Project)/$(LongPackage)/lib
+	$(CC) $(ADDFLAGS) $(LDFLAGS) -o $@ $^ $(Libraries)
+
+$(RPC_MAN_LIB): $(OBJS_RPC_MAN)
+	$(MakeDir) $(BUILD_HOME)/$(Project)/$(LongPackage)/lib
+	$(CC) $(ADDFLAGS) $(LDFLAGS) -o $@ $^ $(Libraries)
+
+$(XHALPY_LIB): $(OBJS_XHALPY)
+	$(MakeDir) $(BUILD_HOME)/$(Project)/$(LongPackage)/lib
+	$(CC) $(ADDFLAGS) $(LDFLAGS) -L$(PYTHON_LIB_PREFIX) -Llib -o $@ $< $(Libraries) -lboost_python -l$(PYTHON_LIB) -lxhal -lrpcman
 
 clean:
-	-rm -rf ${XHALCORE_LIB} ${XHALPY_LIB} ${OBJS_UTILS} ${OBJS_XHAL} ${RPC_MAN_LIB} ${OBJS_RPC_MAN} ${OBJS_XHALPY}
+	-rm -rf $(OBJS_UTILS) $(OBJS_XHAL) $(OBJS_RPC_MAN) $(OBJS_XHALPY)
+	-rm -rf $(XHALCORE_LIB) $(XHALPY_LIB) $(RPC_MAN_LIB)
+	-rm -rf $(BUILD_HOME)/$(Project)/$(LongPackage)/lib
 	-rm -rf $(PackageDir)
 
 cleandoc: 

--- a/xhalcore/Makefile
+++ b/xhalcore/Makefile
@@ -7,7 +7,7 @@ PackageName  := $(ShortPackage)
 PackagePath  := $(shell pwd)
 PackageDir   := pkg/$(ShortPackage)
 Packager     := Mykhailo Dalchenko
-Arch         := x86_64
+#Arch         := x86_64
 
 XHAL_VER_MAJOR:=$(shell $(BUILD_HOME)/$(Project)/config/tag2rel.sh | awk '{split($$0,a," "); print a[1];}' | awk '{split($$0,b,":"); print b[2];}')
 XHAL_VER_MINOR:=$(shell $(BUILD_HOME)/$(Project)/config/tag2rel.sh | awk '{split($$0,a," "); print a[2];}' | awk '{split($$0,b,":"); print b[2];}')
@@ -21,7 +21,7 @@ CCFLAGS=-O0 -g3 -fno-inline -Wall -fPIC -pthread -m64
 ADDFLAGS=-std=c++11
 
 IncludeDirs+= /opt/xdaq/include
-IncludeDirs+= /opt/rh/devtoolset-6/root/usr/include
+# IncludeDirs+= /opt/rh/devtoolset-6/root/usr/include
 IncludeDirs+= ${BUILD_HOME}/${Project}/${LongPackage}/include
 INC=$(IncludeDirs:%=-I%)
 
@@ -47,14 +47,16 @@ XHALPY_LIB=${BUILD_HOME}/${Project}/${LongPackage}/lib/xhalpy.so
 
 .PHONY: clean xhalcore rpc prerpm
 
-default:
+default: build
 	@echo "Running default target"
 	$(MakeDir) $(PackageDir)
 
 _rpmprep: preprpm
 	@echo "Running _rpmprep target"
+
 preprpm: default
 	@echo "Running preprpm target"
+	@cp -rf ../xhalarm/lib lib/arm
 	@cp -rf lib $(PackageDir)
 
 build: xhalcore rpc


### PR DESCRIPTION
## Description
This PR adjusts the build process to bundle the `arm` `libxhal.so` into the `devel` RPM, placing it in
`%{_prefix}/lib/arm/`

### Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Motivation and Context
Some libraries, e.g., `ctp7_modules` require the `arm` version of `libxhal` to be available in order to link properly.  Addressing #97 

## How Has This Been Tested?
Updated libraries have been built (see cms-gem-daq-project/ctp7_modules#77)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
