### PR TITLE
[hotfix] Adapt exception class for const correctness

### DIFF
--- a/xhalcore/include/xhal/utils/Exception.h
+++ b/xhalcore/include/xhal/utils/Exception.h
@@ -26,7 +26,7 @@ namespace xhal {                                                         \
                                                                          \
         }                                                                \
                                                                          \
-        virtual const char* what() {                                     \
+        virtual const char* what() const noexcept (true) override {      \
             return msg.c_str();                                          \
         }                                                                \
                                                                          \


### PR DESCRIPTION
## Description
When migrating functionality in `cmsgemos`, catching the exceptions raised by `xhal` by const reference was breaking `const`-correctness semantics.
The implemented `what()` in `xhal` was not `const`, as it is in the `std::exception` class it inherits from.

### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->

## How Has This Been Tested?
I tested that `ctp7_modules` still compiles (but it doesn't care about much from `xhal`), otherwise, I am not sure what else might be affected by this.  (I would say nothing *should* be, as this change just enforces a contract that was probably already made).
