### PR TITLE
Added Interface for Getting ChipID from RPC Function

### DIFF
--- a/xhalcore/include/xhal/rpc/vfat3.h
+++ b/xhalcore/include/xhal/rpc/vfat3.h
@@ -29,6 +29,14 @@ DLLEXPORT uint32_t configureVFAT3DacMonitorMultiLink(uint32_t ohMask, uint32_t *
  */
 DLLEXPORT uint32_t getChannelRegistersVFAT3(uint32_t ohN, uint32_t vfatMask, uint32_t *chanRegData);
 
+/*! \fn DLLEXPORT uint32_t getVFAT3ChipIDs(uint32_t ohN, uint32_t vfatMask=0xFF000000, bool rawID=false)
+ *  \param chipIDData Array of size 24 that will hold the VFAT ChipID data
+ *  \param ohN Optohybrid optical link number
+ *  \param vfatMask Bitmask of chip positions determining which chips to use
+ *  \param rawID If true the rawID will be returned and reed-muller decoding will not be performed
+ */
+DLLEXPORT uint32_t getVFAT3ChipIDs(uint32_t * chipIDData, uint32_t ohN, uint32_t vfatMask=0xFF000000, bool rawID=false);
+
 /*! \fn DLLEXPORT uint32_t readVFAT3ADC(uint32_t ohN, uint32_t *adcData, bool useExtRefADC=false, uint32_t vfatMask=0xFF000000)
  *  \brief Reads the ADC value from all unmasked VFATs
  *  \param adcData pointer to the array containing the ADC results; length of array is expected to be 24

--- a/xhalcore/src/common/rpc_manager/vfat3.cc
+++ b/xhalcore/src/common/rpc_manager/vfat3.cc
@@ -94,6 +94,38 @@ DLLEXPORT uint32_t getChannelRegistersVFAT3(uint32_t ohN, uint32_t vfatMask, uin
     return 0;
 }
 
+DLLEXPORT uint32_t getVFAT3ChipIDs(uint32_t * chipIDData, uint32_t ohN, uint32_t vfatMask, bool rawID)
+{
+    req = wisc::RPCMsg("vfat3.getVFAT3ChipIDs");
+
+    req.set_word("ohN",ohN);
+    req.set_word("vfatMask",vfatMask);
+    req.set_word("rawID",rawID);
+
+    wisc::RPCSvc* rpc_loc = getRPCptr();
+
+    try {
+        rsp = rpc_loc->call_method(req);
+    }
+    STANDARD_CATCH;
+
+    if (rsp.get_key_exists("error")) {
+        printf("Caught an error: %s\n", (rsp.get_string("error")).c_str());
+        return 1;
+    }
+
+    std::string regBase = "GEM_AMC.OH.OH" + std::to_string(ohN) + ".GEB.VFAT";
+    for(int vfat=0; vfat < 24; ++vfat)
+    {
+        if((vfatMask >> vfat) & 0x1){
+            continue;
+        }
+        chipIDData[vfat] = rsp.get_word(regBase + std::to_string(vfat) + ".HW_CHIP_ID");
+    }
+
+    return 0;
+} //End getVFAT3ChipIDs()
+
 DLLEXPORT uint32_t readVFAT3ADC(uint32_t ohN, uint32_t *adcData, bool useExtRefADC, uint32_t vfatMask){
     req = wisc::RPCMsg("vfat3.readVFAT3ADC");
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added an `xhal` function for retrieving the chipID from the RPC function that uses Reed-Muller decoding.

Requires:
- https://github.com/cms-gem-daq-project/ctp7_modules/pull/99

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
With upcoming VFAT production need the Reed-Muller decoding algorithm to be used.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on QC7 setup with a vfatmask of `0x8`

```python
In [1]: from gempython.tools.vfat_user_functions_xhal import HwVFAT

In [2]: vfatBoard = HwVFAT("eagle60",4)
Open pickled address table if available  /opt/cmsgemos/etc/maps/amc_address_table_top.pickle...
Initializing AMC eagle60
In [5]: chipIDs = vfatBoard.getAllChipIDs(mask=0x8,rawID=False)

In [6]: for vfatN,ID in enumerate(chipIDs):
    print(vfatN,hex(ID))
   ...: 
(0, '0xfbbL')
(1, '0xc440L')
(2, '0xe200L')
(3, '0x0L')
(4, '0x1705L')
(5, '0x3300L')
(6, '0x4610L')
(7, '0x3300L')
(8, '0x2001078L')
(9, '0x3742L')
(10, '0x800f68L')
(11, '0x2ec0L')
(12, '0xd100L')
(13, '0x2ec0L')
(14, '0x401775L')
(15, '0xf69L')
(16, '0xea80L')
(17, '0x3300L')
(18, '0x4841L')
(19, '0xd748L')
(20, '0xd100L')
(21, '0x3300L')
(22, '0xd100L')
(23, '0x40afeL')
```

### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
