### PR TITLE
[hotfix] Add block nodes for legacy

### DIFF
--- a/xhalcore/include/xhal/utils/XHALXMLNode.h
+++ b/xhalcore/include/xhal/utils/XHALXMLNode.h
@@ -61,6 +61,8 @@ namespace xhal {
           //print 'Description:',self.description
           //print 'Address:','{0:#010x}'.format(self.address)
           //print 'Permission:',self.permission
+          //print 'Mode:',self.mode
+          //print 'Size:',self.size
           //print 'Mask:','{0:#010x}'.format(self.mask)
           //print 'Module:',self.isModule
           //print 'Parent:',self.parent.name
@@ -90,6 +92,8 @@ namespace xhal {
         uint32_t address;
         uint32_t real_address;
         std::string permission;
+        std::string mode;
+        uint32_t size;
         uint32_t mask;
         bool isModule;
         Node *parent;

--- a/xhalcore/include/xhal/utils/XHALXMLNode.h
+++ b/xhalcore/include/xhal/utils/XHALXMLNode.h
@@ -3,7 +3,7 @@
  * Flat representation of firmware registers with certain attributes extracted from XML address table
  *
  * @author Mykhailo Dalchenko
- * @version 1.0 
+ * @version 1.0
  */
 
 #ifndef XHAL_UTILS_NODE_H
@@ -27,16 +27,18 @@ namespace xhal {
          */
         Node()
         {
-          name=""; 
-          description=""; 
-          vhdlname = ""; 
-          address = 0x0; 
-          real_address = 0x0; 
-          permission = ""; 
-          mask = 0xFFFFFFFF; 
-          isModule = false; 
-          parent = nullptr; 
-          level = 0; 
+          name="";
+          description="";
+          vhdlname = "";
+          address = 0x0;
+          real_address = 0x0;
+          permission = "";
+          mode = "single";
+          size = 1;
+          mask = 0xFFFFFFFF;
+          isModule = false;
+          parent = nullptr;
+          level = 0;
           warn_min_value = -1;
           error_min_value = -1;
         }
@@ -63,7 +65,7 @@ namespace xhal {
           //print 'Module:',self.isModule
           //print 'Parent:',self.parent.name
         }
-    
+
         /**
          * @brief Returns all hierarchy of chlid nodes
          * @param node parent node
@@ -71,7 +73,7 @@ namespace xhal {
          */
         void getAllChildren(Node node, std::vector<Node> kids)
         {
-          if (node.children.empty()) 
+          if (node.children.empty())
           {
             kids.push_back(node);
           } else {
@@ -81,7 +83,7 @@ namespace xhal {
             }
           }
         }
-    
+
         std::string name;
         std::string description;
         std::string vhdlname;

--- a/xhalcore/src/common/utils/XHALXMLParser.cpp
+++ b/xhalcore/src/common/utils/XHALXMLParser.cpp
@@ -53,7 +53,7 @@ void xhal::utils::XHALXMLParser::parseXML()
     ERROR("Error during Xerces-c Initialization." << std::endl
           << "  Exception message:"
           << xercesc::XMLString::transcode(toCatch.getMessage()));
-    throw xhal::utils::Exception("XHALParser: initialization failed"); 
+    throw xhal::utils::Exception("XHALParser: initialization failed");
     return;
   }
 
@@ -116,7 +116,7 @@ void xhal::utils::XHALXMLParser::parseXML()
     makeTree(m_root,"",0x0,m_nodes,NULL,m_vars,false);
     DEBUG("Number of nodes: " << m_nodes->size());
   } else{
-    throw xhal::utils::Exception("XHALParser: an error occured during parsing"); 
+    throw xhal::utils::Exception("XHALParser: an error occured during parsing");
   }
   DEBUG("Parsing done!");
   if (parser) parser->release();
@@ -161,7 +161,7 @@ void xhal::utils::XHALXMLParser::makeTree(xercesc::DOMNode * node, std::string b
   address = baseAddress;
   if (baseName != "") {name += ".";}
   if (auto tmp = getAttVal(node, "id"))
-  { 
+  {
     name.append(*tmp);
   } else {
     ERROR("getAttVal returned NONE, node has no id attribute");
@@ -171,11 +171,11 @@ void xhal::utils::XHALXMLParser::makeTree(xercesc::DOMNode * node, std::string b
   DEBUG("Node name: " << name);
   newNode.name = name;
   if (auto tmp = getAttVal(node, "description"))
-  { 
+  {
     newNode.description = *tmp;
   }
   if (auto tmp = getAttVal(node, "address"))
-  { 
+  {
     address = baseAddress + parseInt(*tmp);
     newNode.address = address;
     newNode.real_address = (address<<2)+0x64000000;
@@ -183,20 +183,28 @@ void xhal::utils::XHALXMLParser::makeTree(xercesc::DOMNode * node, std::string b
     TRACE("getAttVal returned NONE");
   }
   if (auto tmp = getAttVal(node, "permission"))
-  { 
+  {
     newNode.permission = *tmp;
   }
+  if (auto tmp = getAttVal(node, "mode"))
+  {
+    newNode.mode = *tmp;
+  }
+  if (auto tmp = getAttVal(node, "size"))
+  {
+    newNode.size = parseInt(*tmp);
+  }
   if (auto tmp = getAttVal(node, "mask"))
-  { 
+  {
     newNode.mask = parseInt(*tmp);
   }
   newNode.isModule = (getAttVal(node, "fw_is_module")) && (*getAttVal(node, "fw_is_module") == "true");
   if (auto tmp = getAttVal(node, "sw_monitor_warn_min_threshold"))
-  { 
+  {
     newNode.warn_min_value = parseInt(*tmp);
   }
   if (auto tmp = getAttVal(node, "sw_monitor_error_min_threshold"))
-  { 
+  {
     newNode.warn_min_value = parseInt(*tmp);
   }
 
@@ -213,10 +221,10 @@ void xhal::utils::XHALXMLParser::makeTree(xercesc::DOMNode * node, std::string b
   xercesc::DOMNodeList *children_ = node->getChildNodes();
   const XMLSize_t nodeCount = children_->getLength();
   DEBUG("Node children length: " << nodeCount);
-          
+
   for( XMLSize_t ix = 0 ; ix < nodeCount ; ++ix )
   {
-    if (children_->item(ix)->getNodeType() == xercesc::DOMNode::ELEMENT_NODE) 
+    if (children_->item(ix)->getNodeType() == xercesc::DOMNode::ELEMENT_NODE)
     {
       makeTree(children_->item(ix),name,address,nodes,&newNode,vars,false);
     } else {
@@ -232,7 +240,7 @@ std::experimental::optional<std::string> xhal::utils::XHALXMLParser::getAttVal(x
   xercesc::DOMElement* t_node = static_cast<xercesc::DOMElement*>(t_node_);
   TRACE("tmp: " << tmp);
   TRACE("successfull call of getAttribute: " << t_node->getAttribute(tmp));
-  char * tmp2 = xercesc::XMLString::transcode(t_node->getAttribute(tmp)); 
+  char * tmp2 = xercesc::XMLString::transcode(t_node->getAttribute(tmp));
   TRACE("tmp2: " << tmp2);
   if (tmp2[0]!='\0')
   {
@@ -241,7 +249,7 @@ std::experimental::optional<std::string> xhal::utils::XHALXMLParser::getAttVal(x
     xercesc::XMLString::release(&tmp2);
     TRACE("result " << value);
     return value;
-  } else 
+  } else
   {
     TRACE("Attribute not found");
     xercesc::XMLString::release(&tmp);
@@ -313,13 +321,13 @@ std::experimental::optional<xhal::utils::Node> xhal::utils::XHALXMLParser::getNo
   //for (auto & n: *m_nodes)
   //{
   //  TRACE("Node name: " << n.name);
-  //  if (nodeName == n.name) 
+  //  if (nodeName == n.name)
   //  {
   //    res = &n;
   //    break;
   //  }
   //}
-  //if (res) 
+  //if (res)
   //{
   //  return *res;
   //} else {
@@ -332,13 +340,13 @@ std::experimental::optional<xhal::utils::Node> xhal::utils::XHALXMLParser::getNo
   //Node * res = NULL;
   //for (auto & n: *m_nodes)
   //{
-  //  if (nodeAddress == n.real_address) 
+  //  if (nodeAddress == n.real_address)
   //  {
   //    res = &n;
   //    break;
   //  }
   //}
-  //if (res) 
+  //if (res)
   //{
   //  return *res;
   //} else {


### PR DESCRIPTION
## Description
Ensure that legacy `xhal` can still be used with the uncaring `ctp7_modules`

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
untested
