### PR TITLE
New Feature: Interface for repeated register read

### DIFF
--- a/python/reg_interface_gem/core/reg_extra_ops.py
+++ b/python/reg_interface_gem/core/reg_extra_ops.py
@@ -10,10 +10,18 @@ wReg.argtypes=[c_uint,c_uint]
 rpc_connect = lib.init
 rpc_connect.argtypes = [c_char_p]
 rpc_connect.restype = c_uint
+rpc_disconnect = lib.deinit
+rpc_disconnect.argtypes = [ ]
+rpc_disconnect.restype = c_uint
 
 rBlock = lib.getBlock
 rBlock.restype = c_uint
 rBlock.argtypes=[c_uint,POINTER(c_uint32)]
+
+repeatedRead = lib.repeatedRegRead
+repeatedRead.argtypes = [c_char_p, c_uint, c_bool ]
+repeatedRead.restype = c_uint
+
 getRPCTTCmain = lib.getmonTTCmain
 getRPCTTCmain.argtypes = [POINTER(c_uint32)]
 getRPCTTCmain.restype = c_uint

--- a/xhalcore/include/xhal/rpc/amc.h
+++ b/xhalcore/include/xhal/rpc/amc.h
@@ -2,6 +2,10 @@
 #define AMC_H
 
 #include "xhal/rpc/utils.h"
+#include "xhal/utils/Exception.h"
+
+#include<vector>
+#include<string>
 
 /*! \fn DLLEXPORT uint32_t getOHVFATMask(uint32_t ohN, uint32_t * vfatMask)
  *  \brief Determines the vfatMask for optohybrid ohN.
@@ -17,6 +21,15 @@ DLLEXPORT uint32_t getOHVFATMask(uint32_t ohN);
  *  \param ohVfatMaskArray Pointer to an array of length 12.  After the call completes each element will be the bitmask of chip positions determining which chips to use for the optohybrid number corresponding to the element index.
  */
 DLLEXPORT uint32_t getOHVFATMaskMultiLink(uint32_t ohMask, uint32_t * ohVfatMaskArray);
+
+/*! \fn DLLEXPORT uint32_t repeatedRegRead( const char * regName, uint32_t nReads, bool breakOnFailure)
+ *  \brief repeatedly reads the register regName up to nReads number of times
+ *  \param regName full node name of the register to be read
+ *  \param nReads maximum number of read attempts to be performed
+ *  \param breakOnFailure if true the read process will stop before nReads is reached if a single read fails
+ *  \returns sum of VFAT slow control error counters
+ */
+DLLEXPORT uint32_t repeatedRegRead( const char * regName, uint32_t nReads=1000, bool breakOnFailure=true);
 
 /*! \fn DLLEXPORT uint32_t sbitReadOut(uint32_t ohN, uint32_t acquireTime, uint32_t * approxLiveTime, bool * maxNetworkSizeReached, uint32_t * storedSbits)
  *  \brief SBIT readout from optohybrid ohN for a number of seconds given by acquireTime; data is written to a file directory specified by outFilePath

--- a/xhalcore/include/xhal/rpc/utils.h
+++ b/xhalcore/include/xhal/rpc/utils.h
@@ -25,7 +25,7 @@
 	catch (wisc::RPCMsg::BadKeyException &e) { \
 		printf("Caught exception: %s\n", e.key.c_str()); \
 		return 0xdeaddead; \
-	} 
+	}
 
 #define ASSERT(x) do { \
     if (!(x)) { \
@@ -38,7 +38,8 @@ static wisc::RPCSvc rpc;
 static wisc::RPCMsg req, rsp;
 
 wisc::RPCSvc* getRPCptr();
-DLLEXPORT uint32_t init(char * hostname);
+DLLEXPORT uint32_t deinit();                //disconnect
+DLLEXPORT uint32_t init(char * hostname);   //connect
 DLLEXPORT uint32_t getReg(uint32_t address);
 DLLEXPORT uint32_t putReg(uint32_t address, uint32_t value);
 DLLEXPORT uint32_t getList(uint32_t* addresses, uint32_t* result, ssize_t size);

--- a/xhalcore/src/common/rpc_manager/amc.cc
+++ b/xhalcore/src/common/rpc_manager/amc.cc
@@ -51,6 +51,36 @@ DLLEXPORT uint32_t getOHVFATMaskMultiLink(uint32_t ohMask, uint32_t * ohVfatMask
     return 0;
 } //End getOHVFATMaskMultiLink(...)
 
+DLLEXPORT uint32_t repeatedRegRead( const char * regName, uint32_t nReads, bool breakOnFailure)
+{
+    req = wisc::RPCMsg("amc.repeatedRegRead");
+
+    //Not sure what the best way using ctypes in python is to get a list of strings
+    //An array of char's might be better? But then do they need to have same length...?
+    std::vector<std::string> vec_regList;
+    vec_regList.push_back(regName); //type assignment issue? Maybe case this as a string first...?
+
+    //Set the request keys
+    req.set_string_array("regList",vec_regList);
+    req.set_word("nReads",nReads);
+    req.set_word("breakOnFailure",breakOnFailure);
+
+    wisc::RPCSvc* rpc_loc = getRPCptr();
+
+    try{
+        rsp = rpc_loc->call_method(req);
+    }
+    STANDARD_CATCH;
+
+    if (rsp.get_key_exists("error")){
+        printf("Caught an error: %s\n", (rsp.get_string("error")).c_str());
+        //throw xhal::utils::Exception(strcat("repeatedRegRead: caught an error:", rsp.get_string("error").c_str()));
+        return 0xffffffff;
+    }
+
+    return rsp.get_word("SUM");
+} //End repeatedRegRead
+
 DLLEXPORT uint32_t sbitReadOut(uint32_t ohN, uint32_t acquireTime, char * outFilePath){
     req = wisc::RPCMsg("amc.sbitReadOut");
 

--- a/xhalcore/src/common/rpc_manager/utils.cc
+++ b/xhalcore/src/common/rpc_manager/utils.cc
@@ -2,6 +2,23 @@
 
 wisc::RPCSvc* getRPCptr(){return &rpc;}
 
+DLLEXPORT uint32_t deinit()
+{
+    try {
+        rpc.disconnect();
+    }
+    catch (wisc::RPCSvc::NotConnectedException &e) {
+        printf("Caught exception: Cannot disconnect because I wasn't connected: %s\n", e.message.c_str());
+        return 0;
+    }
+    catch (wisc::RPCSvc::RPCException &e) {
+        printf("Caught exception: %s\n", e.message.c_str());
+        return 1;
+    }
+
+    return 0;
+}
+
 DLLEXPORT uint32_t init(char * hostname)
 {
     try {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adding some functionality to send an RPC call that will repeatedly read a given register and query the VFAT3 slow control error counters to see if a communication error occurred during this period.

Note a bus error (e.g. `0xdeaddead` is returned) when accessing a VFAT register *always* causes the timeout error counter in this block of the AMC FW to increment; so this will catch these type, and other communication errors.

Requires:
- https://github.com/cms-gem-daq-project/ctp7_modules/pull/115

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
Following our conversation about how we would pick a "probably good" GBT phase and then perform `N >> 1` slow control actions with this VFAT it was necessary to implement an RPC method for this and this serves as the interface. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
QC7 land...

### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->