### PR TITLE
Allow multiple GBT phase scan results to be written to the same file

### DIFF
--- a/python/reg_interface_gem/test/.gitattributes
+++ b/python/reg_interface_gem/test/.gitattributes
@@ -1,0 +1,1 @@
+data/** filter=lfs diff=lfs merge=lfs -text

--- a/python/reg_interface_gem/test/data/test_saveGBTPhaseScanResults_AppendToFile.root
+++ b/python/reg_interface_gem/test/data/test_saveGBTPhaseScanResults_AppendToFile.root
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1ca8c7bbc5600fa60d8a8ab421e89569c2a246b6909d54874f212148d1b6e06e
+size 22586

--- a/python/reg_interface_gem/test/data/test_saveGBTPhaseScanResults_NewFile.root
+++ b/python/reg_interface_gem/test/data/test_saveGBTPhaseScanResults_NewFile.root
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b35efe89c3f5192b36cdcd813d4d90a45c4d7262dbcdf864df51e7ff6899fdda
+size 5684

--- a/python/reg_interface_gem/test/test_saveGBTPhaseScanResults.py
+++ b/python/reg_interface_gem/test/test_saveGBTPhaseScanResults.py
@@ -1,0 +1,74 @@
+import unittest
+
+from core.gbt_utils_extended import saveGBTPhaseScanResults
+
+import os
+from tempfile import mkstemp
+from ctypes import c_uint32
+from filecmp import cmp
+
+class TestSaveGBTPhaseScanResults(unittest.TestCase):
+
+    def setUp(self):
+        # Fill in a result array with a known pattern
+        self.phasesBlob = (c_uint32 * (24*16))()
+        for idx in range(len(self.phasesBlob)):
+            self.phasesBlob[idx] = idx
+
+        self.nOfRepetitions = len(self.phasesBlob) - 1
+
+        # Prepare a temp file
+        (self.fd, self.filename) = mkstemp()
+
+    def tearDown(self):
+        # Delete the temp file
+        os.close(self.fd)
+        os.remove(self.filename)
+
+    def testNewFile(self):
+        """
+        Test writing the GBT RX phase scan results of 1 OH to a file.
+        """
+
+        saveGBTPhaseScanResults(self.filename, 0, self.phasesBlob, self.nOfRepetitions)
+
+        # Compare with the reference file
+        referenceFile = os.path.dirname(os.path.abspath(__file__)) + "/data/test_saveGBTPhaseScanResults_NewFile.root"
+        self.assertTrue(cmp(self.filename, referenceFile))
+
+    def testAppendToFile(self):
+        """
+        Test writing the GBT RX phase scan results of 4 OHs to the same file.
+        """
+
+        for i in range(4):
+            saveGBTPhaseScanResults(self.filename, i, self.phasesBlob, self.nOfRepetitions)
+
+        # Compare with the reference file
+        referenceFile = os.path.dirname(os.path.abspath(__file__)) + "/data/test_saveGBTPhaseScanResults_AppendToFile.root"
+        self.assertTrue(cmp(self.filename, referenceFile))
+
+    def testIncorrectHeader(self):
+        """
+        Test the detection of corrupted file with an incorrect header.
+        """
+
+        # Prepare a file with a corrupted header
+        with open(self.filename, 'wb') as f:
+            f.write("ohN/I:vfatN/")
+
+        self.assertRaises(RuntimeError, saveGBTPhaseScanResults, self.filename, 0, self.phasesBlob, self.nOfRepetitions)
+
+    def testMissingEOL(self):
+        """
+        Test the detection of corrupted file with a missing EOL.
+        """
+
+        # Prepare a results file, then delete the trailing EOL
+        saveGBTPhaseScanResults(self.filename, 0, self.phasesBlob, self.nOfRepetitions)
+
+        with open(self.filename, 'r+b') as f:
+            f.seek(-1, 2) # Go to the last character
+            f.truncate()
+
+        self.assertRaises(RuntimeError, saveGBTPhaseScanResults, self.filename, 1, self.phasesBlob, self.nOfRepetitions)


### PR DESCRIPTION
## Description

This PR fixes https://github.com/cms-gem-daq-project/xhal/issues/111.

When the output file already exists, the function performs two sanity checks :
1. It validates the file header.
2. It ensure that the last character is EOL so that the new first line will not be merge with the previous last line.

If both checks pass, the new data are appended to the file. Therefore, it is possible to merge multiple OHs in a single result file.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

New tests have been written and pass :
``` bash
[lpetre@gem-daq reg_interface_gem]$ python -m unittest discover test
....
----------------------------------------------------------------------
Ran 4 tests in 0.019s

OK
```

Moreover the output file has been tested against the scripts from this PR : https://github.com/cms-gem-daq-project/gem-plotting-tools/pull/201. The output plot corresponds to the generated pattern of the tests :

![canv_GBTPhaseScanResults_aa](https://user-images.githubusercontent.com/33247723/56854396-2ae03d00-6936-11e9-8282-09c697a67abe.png)

### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
