### PR TITLE
Feature/ge21 compatibility

### DIFF
--- a/python/reg_interface_gem/core/gbt_utils_extended.py
+++ b/python/reg_interface_gem/core/gbt_utils_extended.py
@@ -8,14 +8,14 @@ def configGBT(cardName, listOfconfigFiles, ohMask = 0xfff, nOHs=12):
     Configures all GBT's for OH's defined in ohMask on cardName
 
     cardName            - network alias of backend AMC
-    listOfconfigFiles   - List of config filenames to be used for all OH's, 
+    listOfconfigFiles   - List of config filenames to be used for all OH's,
                           index of element should match GBTx number on OH, max length of 3
     ohMask              - ohMask to apply, a 1 in the n^th bit indicates the n^th OH should be considered
     nOHs                - Number of OH's on this AMC
     """
 
     rpc_connect(cardName)
-    
+
     if len(listOfconfigFiles) > 3:
         # FIXME less generic exception
         raise RuntimeError("Too many GBT filenames provided, at most 3 files should be given",os.EX_USAGE)
@@ -39,7 +39,7 @@ def configGBT(cardName, listOfconfigFiles, ohMask = 0xfff, nOHs=12):
 
     return
 
-def gbtPhaseScan(cardName, ohMask = 0xfff, nOHs=12, nOfRepetitions=100, silent=True, outputFile=None):
+def gbtPhaseScan(cardName, ohMask = 0xfff, nOHs=12, nOfRepetitions=100, silent=True, outputFile=None, nVFAT=24):
     """
     Scan the VFAT phases for all optohybrids defined in ohMask.
 
@@ -49,7 +49,7 @@ def gbtPhaseScan(cardName, ohMask = 0xfff, nOHs=12, nOfRepetitions=100, silent=T
     nOfRepetitions      - Number of times the scan is performed.
     outputFile          - If provided creates a text file with this name and writes phase scan results to the file
     """
-        
+
     rpc_connect(cardName)
 
     dict_phaseScanResults = {}
@@ -59,7 +59,7 @@ def gbtPhaseScan(cardName, ohMask = 0xfff, nOHs=12, nOfRepetitions=100, silent=T
             continue
 
         # Scan phases
-        phasesBlob = (c_uint32 * (24*16))()
+        phasesBlob = (c_uint32 * (nVFAT*16))()
         scanGBTPhases(phasesBlob, ohN, nOfRepetitions, 0, 15, 1)
         dict_phaseScanResults[ohN] = phasesBlob
 
@@ -68,7 +68,7 @@ def gbtPhaseScan(cardName, ohMask = 0xfff, nOHs=12, nOfRepetitions=100, silent=T
             print("="*20)
             print("Phase Scan Results for OH{0}".format(ohN))
             print("="*20)
-            printGBTPhaseScanResults(phasesBlob)
+            printGBTPhaseScanResults(phasesBlob, nVFAT)
             pass
 
         # File output
@@ -79,7 +79,7 @@ def gbtPhaseScan(cardName, ohMask = 0xfff, nOHs=12, nOfRepetitions=100, silent=T
 
     return dict_phaseScanResults
 
-def printGBTPhaseScanResults(phasesBlob):
+def printGBTPhaseScanResults(phasesBlob, nVFAT=24):
     from tabulate import tabulate
 
     # Create a table with the scan results
@@ -87,14 +87,14 @@ def printGBTPhaseScanResults(phasesBlob):
     for phase in range(16):
         row = []
         row.append(phase)
-        for vfatN in range(24):
+        for vfatN in range(nVFAT):
             row.append(phasesBlob[vfatN*16+phase])
 
         table.append(row)
 
     # Create header for the table
     header = ["Phase"]
-    for vfatN in range(24):
+    for vfatN in range(nVFAT):
         header.append("VFAT" + str(vfatN))
 
     # Print the table
@@ -111,7 +111,7 @@ def readGBTConfigFile(filename):
     else:
         return content[:366]
 
-def saveGBTPhaseScanResults(filename, ohN, phasesBlob, nOfRepetitions=100):
+def saveGBTPhaseScanResults(filename, ohN, phasesBlob, nOfRepetitions=100, nVFAT=24):
     import csv
 
     # Header for the ROOT file
@@ -123,7 +123,7 @@ def saveGBTPhaseScanResults(filename, ohN, phasesBlob, nOfRepetitions=100):
 
     # Parse the data
     data = []
-    for vfatN in range(24):
+    for vfatN in range(nVFAT):
         for phase in range(16):
             nOfSuccesses = phasesBlob[vfatN*16+phase]
             data.append([ohN, vfatN, phase, nOfRepetitions, nOfSuccesses])
@@ -166,13 +166,13 @@ def setPhase(cardName, ohN, vfatN, phase):
     rpcRsp = writeGBTPhase(ohN, vfatN, phase)
     if rpcRsp > 0:
         raise RuntimeError("Failed to write phase {0} to VFAT{1} of OH{2}".format(phase,vfatN,ohN))
-    
+
     return
 
 def setPhaseAllVFATs(cardName, ohN, listOfPhases, debug=False):
     """
     Writes all vfat phases on the provided ohN.
- 
+
     cardName     - network alias of backend AMC
     ohN          - OptoHybrid to configure.
     listOfPhases - List of phases to write, list position should follow vfat position.
@@ -201,9 +201,9 @@ def setPhaseAllVFATs(cardName, ohN, listOfPhases, debug=False):
 def setPhaseAllOHs(cardName, dictOfPhases, ohMask=0xfff, nOHs=12, debug=False):
     """
     For all OH's in ohMask writes the phase for all VFATs
-    
+
     cardName - network alias of backend AMC
-    dictOfPhases - dictionary where key is OH number, each key stores a list of phases for each vfat, 
+    dictOfPhases - dictionary where key is OH number, each key stores a list of phases for each vfat,
                    the index of the list should match the vfat position.
                    If phase is assigned as 0xdeaddead it will not be written
     ohMask - ohMask to apply, a 1 in the n^th bit indicates the n^th OH should be considered

--- a/python/reg_interface_gem/core/gbt_utils_extended.py
+++ b/python/reg_interface_gem/core/gbt_utils_extended.py
@@ -39,7 +39,7 @@ def configGBT(cardName, listOfconfigFiles, ohMask = 0xfff, nOHs=12):
 
     return
 
-def gbtPhaseScan(cardName, ohMask = 0xfff, nOHs=12, nOfRepetitions=100, silent=True, outputFile=None, nVFAT=24):
+def gbtPhaseScan(cardName, ohMask = 0xfff, nOHs=12, nOfRepetitions=100, silent=True, outputFile=None, nVFAT=24, nVerificationReads=10):
     """
     Scan the VFAT phases for all optohybrids defined in ohMask.
 
@@ -60,7 +60,7 @@ def gbtPhaseScan(cardName, ohMask = 0xfff, nOHs=12, nOfRepetitions=100, silent=T
 
         # Scan phases
         phasesBlob = (c_uint32 * (nVFAT*16))()
-        scanGBTPhases(phasesBlob, ohN, nOfRepetitions, 0, 15, 1, nVFAT)
+        scanGBTPhases(phasesBlob, ohN, nOfRepetitions, 0, 15, 1, nVFAT, nVerificationReads)
         dict_phaseScanResults[ohN] = phasesBlob
 
         # stdout output

--- a/python/reg_interface_gem/core/gbt_utils_extended.py
+++ b/python/reg_interface_gem/core/gbt_utils_extended.py
@@ -60,7 +60,7 @@ def gbtPhaseScan(cardName, ohMask = 0xfff, nOHs=12, nOfRepetitions=100, silent=T
 
         # Scan phases
         phasesBlob = (c_uint32 * (nVFAT*16))()
-        scanGBTPhases(phasesBlob, ohN, nOfRepetitions, 0, 15, 1)
+        scanGBTPhases(phasesBlob, ohN, nOfRepetitions, 0, 15, 1, nVFAT)
         dict_phaseScanResults[ohN] = phasesBlob
 
         # stdout output

--- a/python/reg_interface_gem/core/reg_extra_ops.py
+++ b/python/reg_interface_gem/core/reg_extra_ops.py
@@ -52,7 +52,7 @@ rList.argtypes=[POINTER(c_uint32),POINTER(c_uint32)]
 
 scanGBTPhases = lib.scanGBTPhases
 scanGBTPhases.restype = c_uint
-scanGBTPhases.argtype = [POINTER(c_uint), c_uint, c_uint, c_uint, c_uint, c_uint, c_uint]
+scanGBTPhases.argtype = [POINTER(c_uint), c_uint, c_uint, c_uint, c_uint, c_uint, c_uint, c_uint]
 
 update_atdb = lib.update_atdb
 update_atdb.argtypes = [c_char_p]

--- a/python/reg_interface_gem/core/reg_extra_ops.py
+++ b/python/reg_interface_gem/core/reg_extra_ops.py
@@ -52,7 +52,7 @@ rList.argtypes=[POINTER(c_uint32),POINTER(c_uint32)]
 
 scanGBTPhases = lib.scanGBTPhases
 scanGBTPhases.restype = c_uint
-scanGBTPhases.argtype = [POINTER(c_uint), c_uint, c_uint, c_uint, c_uint, c_uint]
+scanGBTPhases.argtype = [POINTER(c_uint), c_uint, c_uint, c_uint, c_uint, c_uint, c_uint]
 
 update_atdb = lib.update_atdb
 update_atdb.argtypes = [c_char_p]

--- a/xhalcore/include/xhal/rpc/calibration_routines.h
+++ b/xhalcore/include/xhal/rpc/calibration_routines.h
@@ -38,14 +38,14 @@ struct vfat3DACSize{
 
 DLLEXPORT uint32_t checkSbitMappingWithCalPulse(uint32_t ohN, uint32_t vfatN, uint32_t mask, bool useCalPulse, bool currentPulse, uint32_t calScaleFactor, uint32_t nevts, uint32_t L1Ainterval, uint32_t pulseDelay, uint32_t *data);
 DLLEXPORT uint32_t checkSbitRateWithCalPulse(uint32_t ohN, uint32_t vfatN, uint32_t mask, bool useCalPulse, bool currentPulse, uint32_t calScaleFactor, uint32_t waitTime, uint32_t pulseRate, uint32_t pulseDelay, uint32_t *outDataCTP7Rate, uint32_t *outDataFPGAClusterCntRate, uint32_t *outDataVFATSBits);
-DLLEXPORT uint32_t dacScan(uint32_t ohN, uint32_t dacSelect, uint32_t dacStep, uint32_t mask, bool useExtRefADC, uint32_t * results);
-DLLEXPORT uint32_t dacScanMultiLink(uint32_t ohMask, uint32_t NOH, uint32_t dacSelect, uint32_t dacStep, bool useExtRefADC, uint32_t * results);
+DLLEXPORT uint32_t dacScan(uint32_t ohN, uint32_t dacSelect, uint32_t dacStep, uint32_t mask, bool useExtRefADC, uint32_t * results, uint32_t nvfats=24);
+DLLEXPORT uint32_t dacScanMultiLink(uint32_t ohMask, uint32_t NOH, uint32_t dacSelect, uint32_t dacStep, bool useExtRefADC, uint32_t * results, uint32_t nvfats=24);
 DLLEXPORT uint32_t genScan(uint32_t nevts, uint32_t ohN, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep,
         uint32_t ch, bool useCalPulse, bool currentPulse, uint32_t calScaleFactor, uint32_t mask, char * scanReg, bool useUltra, bool useExtTrig,
-        uint32_t * result);
-DLLEXPORT uint32_t genChannelScan(uint32_t nevts, uint32_t ohN, uint32_t mask, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep, bool useCalPulse, bool currentPulse, uint32_t calScaleFactor, bool useExtTrig, char * scanReg, bool useUltra, uint32_t * result);
+        uint32_t * result, uint32_t nvfats=24);
+DLLEXPORT uint32_t genChannelScan(uint32_t nevts, uint32_t ohN, uint32_t mask, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep, bool useCalPulse, bool currentPulse, uint32_t calScaleFactor, bool useExtTrig, char * scanReg, bool useUltra, uint32_t * result, uint32_t nvfats=24);
 DLLEXPORT uint32_t sbitRateScan(uint32_t ohMask, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep, uint32_t ch,
-        char * scanReg, uint32_t * resultDacVal, uint32_t * resultTrigRate, uint32_t * resultTrigRatePerVFAT);
+        char * scanReg, uint32_t * resultDacVal, uint32_t * resultTrigRate, uint32_t * resultTrigRatePerVFAT, uint32_t nvfats=24);
 DLLEXPORT uint32_t ttcGenConf(uint32_t ohN, uint32_t mode, uint32_t type, uint32_t pulseDelay,
         uint32_t L1Ainterval, uint32_t nPulses, bool enable);
 DLLEXPORT uint32_t ttcGenToggle(uint32_t ohN, bool enable);

--- a/xhalcore/include/xhal/rpc/daq_monitor.h
+++ b/xhalcore/include/xhal/rpc/daq_monitor.h
@@ -58,7 +58,7 @@ DLLEXPORT uint32_t getmonTRIGGERmain(uint32_t* result, uint32_t noh = 12, uint32
 DLLEXPORT uint32_t getmonTRIGGEROHmain(uint32_t* result, uint32_t noh = 12, uint32_t ohMask = 0xff);
 DLLEXPORT uint32_t getmonDAQmain(uint32_t* result);
 DLLEXPORT uint32_t getmonDAQOHmain(uint32_t* result, uint32_t noh = 12, uint32_t ohMask = 0xfff);
-DLLEXPORT uint32_t getmonGBTLink(struct OHLinkMonitor *ohLinkMon, uint32_t noh = 12, uint32_t ohMask = 0xfff, bool doReset = false);
+DLLEXPORT uint32_t getmonGBTLink(struct OHLinkMonitor *ohLinkMon, uint32_t noh = 12, uint32_t ohMask = 0xfff, bool doReset = false, uint32_t NGBT=3);
 DLLEXPORT uint32_t getmonOHLink(struct OHLinkMonitor *ohLinkMon, struct VFATLinkMonitor *vfatLinkMon, uint32_t noh = 12, uint32_t ohMask = 0xfff, bool doReset = false);
 DLLEXPORT uint32_t getmonOHmain(uint32_t* result, uint32_t noh = 12, uint32_t ohMask = 0xfff);
 DLLEXPORT uint32_t getmonOHSCAmain(struct SCAMonitor *scaMon, uint32_t noh = 12, uint32_t ohMask = 0xfff);

--- a/xhalcore/include/xhal/rpc/gbt.h
+++ b/xhalcore/include/xhal/rpc/gbt.h
@@ -3,7 +3,7 @@
 
 #include "xhal/rpc/utils.h"
 
-DLLEXPORT uint32_t scanGBTPhases(uint32_t *result, uint32_t ohN, uint32_t nScans=100, uint32_t phaseMin=0, uint32_t phaseMax=15, uint32_t phaseStep=1);
+DLLEXPORT uint32_t scanGBTPhases(uint32_t *result, uint32_t ohN, uint32_t nScans=100, uint32_t phaseMin=0, uint32_t phaseMax=15, uint32_t phaseStep=1, uint32_t nVFAT=24);
 DLLEXPORT uint32_t writeGBTConfig(uint32_t ohN, uint32_t gbtN, uint32_t configSize, uint8_t *config);
 DLLEXPORT uint32_t writeGBTPhase(uint32_t ohN, uint32_t vfatN, uint8_t phase);
 

--- a/xhalcore/include/xhal/rpc/gbt.h
+++ b/xhalcore/include/xhal/rpc/gbt.h
@@ -3,7 +3,7 @@
 
 #include "xhal/rpc/utils.h"
 
-DLLEXPORT uint32_t scanGBTPhases(uint32_t *result, uint32_t ohN, uint32_t nScans=100, uint32_t phaseMin=0, uint32_t phaseMax=15, uint32_t phaseStep=1, uint32_t nVFAT=24, uint32_t nVerificationReads);
+DLLEXPORT uint32_t scanGBTPhases(uint32_t *result, uint32_t ohN, uint32_t nScans=100, uint32_t phaseMin=0, uint32_t phaseMax=15, uint32_t phaseStep=1, uint32_t nVFAT=24, uint32_t nVerificationReads=10);
 DLLEXPORT uint32_t writeGBTConfig(uint32_t ohN, uint32_t gbtN, uint32_t configSize, uint8_t *config);
 DLLEXPORT uint32_t writeGBTPhase(uint32_t ohN, uint32_t vfatN, uint8_t phase);
 

--- a/xhalcore/include/xhal/rpc/gbt.h
+++ b/xhalcore/include/xhal/rpc/gbt.h
@@ -3,7 +3,7 @@
 
 #include "xhal/rpc/utils.h"
 
-DLLEXPORT uint32_t scanGBTPhases(uint32_t *result, uint32_t ohN, uint32_t nScans=100, uint32_t phaseMin=0, uint32_t phaseMax=15, uint32_t phaseStep=1, uint32_t nVFAT=24);
+DLLEXPORT uint32_t scanGBTPhases(uint32_t *result, uint32_t ohN, uint32_t nScans=100, uint32_t phaseMin=0, uint32_t phaseMax=15, uint32_t phaseStep=1, uint32_t nVFAT=24, uint32_t nVerificationReads);
 DLLEXPORT uint32_t writeGBTConfig(uint32_t ohN, uint32_t gbtN, uint32_t configSize, uint8_t *config);
 DLLEXPORT uint32_t writeGBTPhase(uint32_t ohN, uint32_t vfatN, uint8_t phase);
 

--- a/xhalcore/include/xhal/rpc/optohybrid.h
+++ b/xhalcore/include/xhal/rpc/optohybrid.h
@@ -3,13 +3,13 @@
 
 #include "xhal/rpc/utils.h"
 
-DLLEXPORT uint32_t broadcastRead(uint32_t ohN, char * regName, uint32_t vfatMask, uint32_t * result);
+DLLEXPORT uint32_t broadcastRead(uint32_t ohN, char * regName, uint32_t vfatMask, uint32_t * result, uint32_t size=24);
 DLLEXPORT uint32_t broadcastWrite(uint32_t ohN, char * regName, uint32_t value, uint32_t vfatMask);
 DLLEXPORT uint32_t configureScanModule(uint32_t ohN, uint32_t vfatN, uint32_t scanmode, bool useUltra,
         uint32_t vfatMask, uint32_t ch, uint32_t nevts, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep);
 DLLEXPORT uint32_t printScanConfiguration(uint32_t ohN, bool useUltra);
 DLLEXPORT uint32_t startScanModule(uint32_t ohN, bool useUltra);
-DLLEXPORT uint32_t getUltraScanResults(uint32_t ohN, uint32_t nevts, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep, uint32_t * result);
+DLLEXPORT uint32_t getUltraScanResults(uint32_t ohN, uint32_t nevts, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep, uint32_t * result, uint32_t nvfats=24);
 DLLEXPORT uint32_t stopCalPulse2AllChannels(uint32_t ohN, uint32_t mask, uint32_t ch_min, uint32_t ch_max);
 
 #endif

--- a/xhalcore/include/xhal/rpc/vfat3.h
+++ b/xhalcore/include/xhal/rpc/vfat3.h
@@ -21,41 +21,43 @@ DLLEXPORT uint32_t configureVFAT3DacMonitor(uint32_t ohN, uint32_t vfatMask, uin
  */
 DLLEXPORT uint32_t configureVFAT3DacMonitorMultiLink(uint32_t ohMask, uint32_t *ohVfatMaskArray, uint32_t dacSelect);
 
-/*! \fn DLLEXPORT uint32_t getChannelRegistersVFAT3(uint32_t ohN, uint32_t vfatMask, uint32_t *chanRegData);
+/*! \fn DLLEXPORT uint32_t getChannelRegistersVFAT3(uint32_t ohN, uint32_t vfatMask, uint32_t *chanRegData, uint32_t nvfats=24);
  *  \brief reads channel registers of all unmasked vfats on ohN
  *  \param ohN Optohybrid optical link number
  *  \param vfatMask Bitmask of chip positions determining which chips to use
  *  \param chanRegData array pointer for channel register data with 3072 entries, the (vfat,chan) pairing determines the array index via: idx = vfat*128 + chan
  */
-DLLEXPORT uint32_t getChannelRegistersVFAT3(uint32_t ohN, uint32_t vfatMask, uint32_t *chanRegData);
+DLLEXPORT uint32_t getChannelRegistersVFAT3(uint32_t ohN, uint32_t vfatMask, uint32_t *chanRegData, uint32_t nvfats=24);
 
-/*! \fn DLLEXPORT uint32_t getVFAT3ChipIDs(uint32_t ohN, uint32_t vfatMask=0xFF000000, bool rawID=false)
+/*! \fn DLLEXPORT uint32_t getVFAT3ChipIDs(uint32_t ohN, uint32_t vfatMask=0xFF000000, bool rawID=false, uint32_t nvfats=24)
  *  \param chipIDData Array of size 24 that will hold the VFAT ChipID data
  *  \param ohN Optohybrid optical link number
  *  \param vfatMask Bitmask of chip positions determining which chips to use
  *  \param rawID If true the rawID will be returned and reed-muller decoding will not be performed
+ *  \param nvfats number of VFAT chips per optical link
  */
-DLLEXPORT uint32_t getVFAT3ChipIDs(uint32_t * chipIDData, uint32_t ohN, uint32_t vfatMask=0xFF000000, bool rawID=false);
+DLLEXPORT uint32_t getVFAT3ChipIDs(uint32_t * chipIDData, uint32_t ohN, uint32_t vfatMask=0xFF000000, bool rawID=false, uint32_t nvfats=24);
 
-/*! \fn DLLEXPORT uint32_t readVFAT3ADC(uint32_t ohN, uint32_t *adcData, bool useExtRefADC=false, uint32_t vfatMask=0xFF000000)
+/*! \fn DLLEXPORT uint32_t readVFAT3ADC(uint32_t ohN, uint32_t *adcData, bool useExtRefADC=false, uint32_t vfatMask=0xFF000000, uint32_t nvfats=24)
  *  \brief Reads the ADC value from all unmasked VFATs
  *  \param adcData pointer to the array containing the ADC results; length of array is expected to be 24
  *  \param ohN Optohybrid optical link number
  *  \param useExtRefADC true (false) read the ADC1 (ADC0) which uses an external (internal) reference
  *  \param vfatMask Bitmask of chip positions determining which chips to use
+ *  \param nvfats number of VFAT chips per optical link
  */
-DLLEXPORT uint32_t readVFAT3ADC(uint32_t ohN, uint32_t *adcData, bool useExtRefADC=false, uint32_t vfatMask=0xFF000000);
+DLLEXPORT uint32_t readVFAT3ADC(uint32_t ohN, uint32_t *adcData, bool useExtRefADC=false, uint32_t vfatMask=0xFF000000, uint32_t nvfats=24);
 
-/*! \fn DLLEXPORT uint32_t readVFAT3ADCMultiLink(uint32_t ohN, uint32_t *adcData, bool useExtRefADC=false, uint32_t vfatMask=0xFF000000)
- *  \brief As readVFAT3ADC(...) but for all optical links specified in ohMask on the AMC
+/*! \fn DLLEXPORT uint32_t readVFAT3ADCMultiLink(uint32_t ohMask, uint32_t *ohVfatMaskArray, uint32_t *adcDataAll, bool useExtRefADC=false, uint32_t nvfats=24) *  \brief As readVFAT3ADC(...) but for all optical links specified in ohMask on the AMC
  *  \param ohMask A 12 bit number which specifies which optohybrids to read from.  Having a value of 1 in the n^th bit indicates that the n^th optohybrid should be considered.
  *  \param ohVfatMaskArray Pointer to an array of length 12.  Each element is the bitmask of chip positions determining which chips to use for the optohybrid number corresponding to the element index.
  *  \param adcDataAll pointer to the array containing the ADC results; length of array is expected to be 12*24=288
  *  \param useExtRefADC true (false) read the ADC1 (ADC0) which uses an external (internal) reference
+ *  \param nvfats number of VFAT chips per optical link
  */
-DLLEXPORT uint32_t readVFAT3ADCMultiLink(uint32_t ohMask, uint32_t *ohVfatMaskArray, uint32_t *adcDataAll, bool useExtRefADC=false);
+DLLEXPORT uint32_t readVFAT3ADCMultiLink(uint32_t ohMask, uint32_t *ohVfatMaskArray, uint32_t *adcDataAll, bool useExtRefADC=false, uint32_t nvfats=24);
 
-/*! \fn DLLEXPORT uint32_t setChannelRegistersVFAT3(uint32_t ohN, uint32_t vfatMask, uint32_t *calEnable, uint32_t *masks, uint32_t *trimARM, uint32_t *trimARMPol, uint32_t *trimZCC, uint32_t *trimZCCPol)
+/*! \fn DLLEXPORT uint32_t setChannelRegistersVFAT3(uint32_t ohN, uint32_t vfatMask, uint32_t *calEnable, uint32_t *masks, uint32_t *trimARM, uint32_t *trimARMPol, uint32_t *trimZCC, uint32_t *trimZCCPol, uint32_t nvfats=24)
  *  \brief sets all vfat3 channel registers
  *  \param ohN Optohybrid optical link number
  *  \param vfatMask Bitmask of chip positions determining which chips to use
@@ -65,15 +67,17 @@ DLLEXPORT uint32_t readVFAT3ADCMultiLink(uint32_t ohMask, uint32_t *ohVfatMaskAr
  *  \param trimARMPol as calEnable but for arming comparator trim polarity
  *  \param trimZCC as calEnable but for zero crossing comparator trim value
  *  \param trimZCCPol as calEnable but for zero crossing comparator trim polarity
+ *  \param nvfats number of VFAT chips per optical link
  */
-DLLEXPORT uint32_t setChannelRegistersVFAT3(uint32_t ohN, uint32_t vfatMask, uint32_t *calEnable, uint32_t *masks, uint32_t *trimARM, uint32_t *trimARMPol, uint32_t *trimZCC, uint32_t *trimZCCPol);
+DLLEXPORT uint32_t setChannelRegistersVFAT3(uint32_t ohN, uint32_t vfatMask, uint32_t *calEnable, uint32_t *masks, uint32_t *trimARM, uint32_t *trimARMPol, uint32_t *trimZCC, uint32_t *trimZCCPol, uint32_t nvfats=24);
 
-/*! \fn DLLEXPORT uint32_t setChannelRegistersVFAT3Simple(uint32_t ohN, uint32_t vfatMask, uint32_t *chanRegData)
+/*! \fn DLLEXPORT uint32_t setChannelRegistersVFAT3Simple(uint32_t ohN, uint32_t vfatMask, uint32_t *chanRegData, uint32_t nvfats=24)
  *  \brief sets all vfat3 channel registers using a single channel register array
  *  \param ohN Optohybrid optical link number
  *  \param vfatMask Bitmask of chip positions determining which chips to use
  *  \param chanRegData array pointer for channel register data with 3072 entries, the (vfat,chan) pairing determines the array index via: idx = vfat*128 + chan
+ *  \param nvfats number of VFAT chips per optical link
  */
-DLLEXPORT uint32_t setChannelRegistersVFAT3Simple(uint32_t ohN, uint32_t vfatMask, uint32_t *chanRegData);
+DLLEXPORT uint32_t setChannelRegistersVFAT3Simple(uint32_t ohN, uint32_t vfatMask, uint32_t *chanRegData, uint32_t nvfats=24);
 
 #endif

--- a/xhalcore/src/common/rpc_manager/calibration_routines.cc
+++ b/xhalcore/src/common/rpc_manager/calibration_routines.cc
@@ -94,7 +94,7 @@ DLLEXPORT uint32_t checkSbitRateWithCalPulse(uint32_t ohN, uint32_t vfatN, uint3
     return 0;
 } //End checkSbitRateWithCalPulse()
 
-DLLEXPORT uint32_t dacScan(uint32_t ohN, uint32_t dacSelect, uint32_t dacStep, uint32_t mask, bool useExtRefADC, uint32_t * results){
+DLLEXPORT uint32_t dacScan(uint32_t ohN, uint32_t dacSelect, uint32_t dacStep, uint32_t mask, bool useExtRefADC, uint32_t * results, nvfats){
     req = wisc::RPCMsg("calibration_routines.dacScan");
 
     req.set_word("ohN", ohN);
@@ -116,7 +116,7 @@ DLLEXPORT uint32_t dacScan(uint32_t ohN, uint32_t dacSelect, uint32_t dacStep, u
     }
 
     vfat3DACSize dacSize;
-    const uint32_t size = (dacSize.max[dacSelect]+1)*24/dacStep;
+    const uint32_t size = (dacSize.max[dacSelect]+1)*nvfats/dacStep;
     if (rsp.get_key_exists("dacScanResults")) {
         ASSERT(rsp.get_word_array_size("dacScanResults") == size);
         rsp.get_word_array("dacScanResults", results);
@@ -128,7 +128,7 @@ DLLEXPORT uint32_t dacScan(uint32_t ohN, uint32_t dacSelect, uint32_t dacStep, u
     return 0;
 } //End dacScan()
 
-DLLEXPORT uint32_t dacScanMultiLink(uint32_t ohMask, uint32_t NOH, uint32_t dacSelect, uint32_t dacStep, bool useExtRefADC, uint32_t * results){
+DLLEXPORT uint32_t dacScanMultiLink(uint32_t ohMask, uint32_t NOH, uint32_t dacSelect, uint32_t dacStep, bool useExtRefADC, uint32_t * results, nvfats){
     req = wisc::RPCMsg("calibration_routines.dacScanMultiLink");
 
     req.set_word("ohMask", ohMask);
@@ -150,7 +150,7 @@ DLLEXPORT uint32_t dacScanMultiLink(uint32_t ohMask, uint32_t NOH, uint32_t dacS
     }
 
     vfat3DACSize dacSize;
-    const uint32_t size = NOH * (dacSize.max[dacSelect]+1)*12/dacStep; //FIXME
+    const uint32_t size = NOH * (dacSize.max[dacSelect]+1)*nvfats/dacStep;
     if (rsp.get_key_exists("dacScanResultsAll")) {
         ASSERT(rsp.get_word_array_size("dacScanResultsAll") == size);
         rsp.get_word_array("dacScanResultsAll", results);
@@ -165,7 +165,7 @@ DLLEXPORT uint32_t dacScanMultiLink(uint32_t ohMask, uint32_t NOH, uint32_t dacS
 /***
  * @brief run a generic scan routine for a specific channel
  */
-DLLEXPORT uint32_t genScan(uint32_t nevts, uint32_t ohN, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep, uint32_t ch, bool useCalPulse, bool currentPulse, uint32_t calScaleFactor, uint32_t mask, char * scanReg, bool useUltra, bool useExtTrig, uint32_t * result)
+DLLEXPORT uint32_t genScan(uint32_t nevts, uint32_t ohN, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep, uint32_t ch, bool useCalPulse, bool currentPulse, uint32_t calScaleFactor, uint32_t mask, char * scanReg, bool useUltra, bool useExtTrig, uint32_t * result, uint32_t nvfats)
 {
     req = wisc::RPCMsg("calibration_routines.genScan");
 
@@ -196,7 +196,7 @@ DLLEXPORT uint32_t genScan(uint32_t nevts, uint32_t ohN, uint32_t dacMin, uint32
         printf("Caught an error: %s\n", (rsp.get_string("error")).c_str());
         return 1;
     }
-    const uint32_t size = (dacMax - dacMin+1)*12/dacStep; //FIXME
+    const uint32_t size = (dacMax - dacMin+1)*nvfats/dacStep;
     if (rsp.get_key_exists("data")) {
         ASSERT(rsp.get_word_array_size("data") == size);
         rsp.get_word_array("data", result);
@@ -211,7 +211,7 @@ DLLEXPORT uint32_t genScan(uint32_t nevts, uint32_t ohN, uint32_t dacMin, uint32
 /***
  * @brief run a generic scan routine on all channels
  */
-DLLEXPORT uint32_t genChannelScan(uint32_t nevts, uint32_t ohN, uint32_t mask, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep, bool useCalPulse, bool currentPulse, uint32_t calScaleFactor, bool useExtTrig, char * scanReg, bool useUltra, uint32_t * result){
+DLLEXPORT uint32_t genChannelScan(uint32_t nevts, uint32_t ohN, uint32_t mask, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep, bool useCalPulse, bool currentPulse, uint32_t calScaleFactor, bool useExtTrig, char * scanReg, bool useUltra, uint32_t * result, uint32_t nvfats){
     req = wisc::RPCMsg("calibration_routines.genChannelScan");
 
     req.set_word("nevts", nevts);
@@ -240,7 +240,7 @@ DLLEXPORT uint32_t genChannelScan(uint32_t nevts, uint32_t ohN, uint32_t mask, u
         printf("Caught an error: %s\n", (rsp.get_string("error")).c_str());
         return 1;
     }
-    const uint32_t size = 24*128*(dacMax-dacMin+1)/dacStep;
+    const uint32_t size = nvfats*128*(dacMax-dacMin+1)/dacStep;
     if (rsp.get_key_exists("data")) {
         ASSERT(rsp.get_word_array_size("data") == size);
         rsp.get_word_array("data", result);
@@ -252,7 +252,7 @@ DLLEXPORT uint32_t genChannelScan(uint32_t nevts, uint32_t ohN, uint32_t mask, u
     return 0;
 } //End genChannelScan()
 
-DLLEXPORT uint32_t sbitRateScan(uint32_t ohMask, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep, uint32_t ch, char * scanReg, uint32_t * resultDacVal, uint32_t * resultTrigRate, uint32_t * resultTrigRatePerVFAT)
+DLLEXPORT uint32_t sbitRateScan(uint32_t ohMask, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep, uint32_t ch, char * scanReg, uint32_t * resultDacVal, uint32_t * resultTrigRate, uint32_t * resultTrigRatePerVFAT, uint32_t nvfats)
 {
     req = wisc::RPCMsg("calibration_routines.sbitRateScan");
 
@@ -299,7 +299,7 @@ DLLEXPORT uint32_t sbitRateScan(uint32_t ohMask, uint32_t dacMin, uint32_t dacMa
     }
 
     if (rsp.get_key_exists("outDataVFATRate")) {
-        ASSERT(rsp.get_word_array_size("outDataVFATRate") == (size*24));
+        ASSERT(rsp.get_word_array_size("outDataVFATRate") == (size*nvfats));
         rsp.get_word_array("outDataVFATRate", resultTrigRatePerVFAT);
     }
     else{

--- a/xhalcore/src/common/rpc_manager/calibration_routines.cc
+++ b/xhalcore/src/common/rpc_manager/calibration_routines.cc
@@ -196,7 +196,7 @@ DLLEXPORT uint32_t genScan(uint32_t nevts, uint32_t ohN, uint32_t dacMin, uint32
         printf("Caught an error: %s\n", (rsp.get_string("error")).c_str());
         return 1;
     }
-    const uint32_t size = (dacMax - dacMin+1)*24/dacStep;
+    const uint32_t size = (dacMax - dacMin+1)*12/dacStep; //FIXME
     if (rsp.get_key_exists("data")) {
         ASSERT(rsp.get_word_array_size("data") == size);
         rsp.get_word_array("data", result);

--- a/xhalcore/src/common/rpc_manager/calibration_routines.cc
+++ b/xhalcore/src/common/rpc_manager/calibration_routines.cc
@@ -150,7 +150,7 @@ DLLEXPORT uint32_t dacScanMultiLink(uint32_t ohMask, uint32_t NOH, uint32_t dacS
     }
 
     vfat3DACSize dacSize;
-    const uint32_t size = NOH * (dacSize.max[dacSelect]+1)*24/dacStep;
+    const uint32_t size = NOH * (dacSize.max[dacSelect]+1)*12/dacStep; //FIXME
     if (rsp.get_key_exists("dacScanResultsAll")) {
         ASSERT(rsp.get_word_array_size("dacScanResultsAll") == size);
         rsp.get_word_array("dacScanResultsAll", results);

--- a/xhalcore/src/common/rpc_manager/calibration_routines.cc
+++ b/xhalcore/src/common/rpc_manager/calibration_routines.cc
@@ -94,7 +94,7 @@ DLLEXPORT uint32_t checkSbitRateWithCalPulse(uint32_t ohN, uint32_t vfatN, uint3
     return 0;
 } //End checkSbitRateWithCalPulse()
 
-DLLEXPORT uint32_t dacScan(uint32_t ohN, uint32_t dacSelect, uint32_t dacStep, uint32_t mask, bool useExtRefADC, uint32_t * results, nvfats){
+DLLEXPORT uint32_t dacScan(uint32_t ohN, uint32_t dacSelect, uint32_t dacStep, uint32_t mask, bool useExtRefADC, uint32_t * results, uint32_t nvfats){
     req = wisc::RPCMsg("calibration_routines.dacScan");
 
     req.set_word("ohN", ohN);
@@ -128,7 +128,7 @@ DLLEXPORT uint32_t dacScan(uint32_t ohN, uint32_t dacSelect, uint32_t dacStep, u
     return 0;
 } //End dacScan()
 
-DLLEXPORT uint32_t dacScanMultiLink(uint32_t ohMask, uint32_t NOH, uint32_t dacSelect, uint32_t dacStep, bool useExtRefADC, uint32_t * results, nvfats){
+DLLEXPORT uint32_t dacScanMultiLink(uint32_t ohMask, uint32_t NOH, uint32_t dacSelect, uint32_t dacStep, bool useExtRefADC, uint32_t * results, uint32_t nvfats){
     req = wisc::RPCMsg("calibration_routines.dacScanMultiLink");
 
     req.set_word("ohMask", ohMask);

--- a/xhalcore/src/common/rpc_manager/daq_monitor.cc
+++ b/xhalcore/src/common/rpc_manager/daq_monitor.cc
@@ -458,9 +458,15 @@ DLLEXPORT uint32_t getmonVFATLink(struct VFATLinkMonitor *vfatLinkMon, uint32_t 
                 for(int vfatN = 0; vfatN < 24; ++vfatN){
                     std::string strVFATN = "VFAT" + std::to_string(vfatN) + ".";
 
-                    vfatLinkMon[ohN].daqCRCErrCnt[vfatN] = rsp.get_word(strOHN + strVFATN + "DAQ_CRC_ERROR_CNT");
-                    vfatLinkMon[ohN].daqEvtCnt[vfatN] = rsp.get_word(strOHN + strVFATN + "DAQ_EVENT_CNT");
-                    vfatLinkMon[ohN].syncErrCnt[vfatN] = rsp.get_word(strOHN + strVFATN + "SYNC_ERR_CNT");
+                    if (rsp.get_key_exists(strOHN + strVFATN + "DAQ_CRC_ERROR_CNT")) {
+                        vfatLinkMon[ohN].daqCRCErrCnt[vfatN] = rsp.get_word(strOHN + strVFATN + "DAQ_CRC_ERROR_CNT");
+                        vfatLinkMon[ohN].daqEvtCnt[vfatN] = rsp.get_word(strOHN + strVFATN + "DAQ_EVENT_CNT");
+                        vfatLinkMon[ohN].syncErrCnt[vfatN] = rsp.get_word(strOHN + strVFATN + "SYNC_ERR_CNT");
+                    } else {
+                        vfatLinkMon[ohN].daqCRCErrCnt[vfatN] = 0xdeaddead;
+                        vfatLinkMon[ohN].daqEvtCnt[vfatN] = 0xdeaddead;
+                        vfatLinkMon[ohN].syncErrCnt[vfatN] = 0xdeaddead;
+                    }
                 } //End Loop Over VFAT
             } //End Loop Over OH
         } //End Case: No Error

--- a/xhalcore/src/common/rpc_manager/daq_monitor.cc
+++ b/xhalcore/src/common/rpc_manager/daq_monitor.cc
@@ -187,7 +187,7 @@ DLLEXPORT uint32_t getmonDAQOHmain(uint32_t* result, uint32_t noh, uint32_t ohMa
     return 0;
 }
 
-DLLEXPORT uint32_t getmonGBTLink(struct OHLinkMonitor *ohLinkMon, uint32_t noh, uint32_t ohMask, bool doReset)
+DLLEXPORT uint32_t getmonGBTLink(struct OHLinkMonitor *ohLinkMon, uint32_t noh, uint32_t ohMask, bool doReset, uint32_t NGBT)
 {
     req = wisc::RPCMsg("daq_monitor.getmonGBTLink");
     req.set_word("NOH",noh);
@@ -211,7 +211,7 @@ DLLEXPORT uint32_t getmonGBTLink(struct OHLinkMonitor *ohLinkMon, uint32_t noh, 
 
                 std::string strOHN = "OH" + std::to_string(ohN) + ".";
 
-                for(int gbtN = 0; gbtN < 3; ++gbtN){
+                for(int gbtN = 0; gbtN < NGBT; ++gbtN){
                     std::string strGBTN = "GBT" + std::to_string(gbtN) + ".";
 
                     ohLinkMon[ohN].gbtRdy[gbtN] = rsp.get_word(strOHN + strGBTN + "READY");

--- a/xhalcore/src/common/rpc_manager/gbt.cc
+++ b/xhalcore/src/common/rpc_manager/gbt.cc
@@ -1,6 +1,6 @@
 #include "xhal/rpc/gbt.h"
 
-DLLEXPORT uint32_t scanGBTPhases(uint32_t *results, uint32_t ohN, uint32_t nScans, uint32_t phaseMin, uint32_t phaseMax, uint32_t phaseStep, uint32_t nVFAT)
+DLLEXPORT uint32_t scanGBTPhases(uint32_t *results, uint32_t ohN, uint32_t nScans, uint32_t phaseMin, uint32_t phaseMax, uint32_t phaseStep, uint32_t nVFAT, uint32_t nVerificationReads)
 {
     req = wisc::RPCMsg("gbt.scanGBTPhases");
 
@@ -9,6 +9,7 @@ DLLEXPORT uint32_t scanGBTPhases(uint32_t *results, uint32_t ohN, uint32_t nScan
     req.set_word("phaseMin", phaseMin);
     req.set_word("phaseMax", phaseMax);
     req.set_word("phaseStep", phaseStep);
+    req.set_word("nVerificationReads", nVerificationReads);
 
     wisc::RPCSvc* rpc_loc = getRPCptr();
 

--- a/xhalcore/src/common/rpc_manager/gbt.cc
+++ b/xhalcore/src/common/rpc_manager/gbt.cc
@@ -1,6 +1,6 @@
 #include "xhal/rpc/gbt.h"
 
-DLLEXPORT uint32_t scanGBTPhases(uint32_t *results, uint32_t ohN, uint32_t nScans, uint32_t phaseMin, uint32_t phaseMax, uint32_t phaseStep)
+DLLEXPORT uint32_t scanGBTPhases(uint32_t *results, uint32_t ohN, uint32_t nScans, uint32_t phaseMin, uint32_t phaseMax, uint32_t phaseStep, uint32_t NVFAT = 24)
 {
     req = wisc::RPCMsg("gbt.scanGBTPhases");
 
@@ -22,7 +22,7 @@ DLLEXPORT uint32_t scanGBTPhases(uint32_t *results, uint32_t ohN, uint32_t nScan
         return 1;
     }
 
-    for (unsigned int vfatN = 0; vfatN < 24; vfatN++)
+    for (unsigned int vfatN = 0; vfatN < NVFAT; vfatN++)
     {
         const std::string resultsKey = "OH" + std::to_string(ohN) + ".VFAT" + std::to_string(vfatN);
         if (rsp.get_key_exists(resultsKey)){

--- a/xhalcore/src/common/rpc_manager/gbt.cc
+++ b/xhalcore/src/common/rpc_manager/gbt.cc
@@ -1,6 +1,6 @@
 #include "xhal/rpc/gbt.h"
 
-DLLEXPORT uint32_t scanGBTPhases(uint32_t *results, uint32_t ohN, uint32_t nScans, uint32_t phaseMin, uint32_t phaseMax, uint32_t phaseStep, uint32_t NVFAT = 24)
+DLLEXPORT uint32_t scanGBTPhases(uint32_t *results, uint32_t ohN, uint32_t nScans, uint32_t phaseMin, uint32_t phaseMax, uint32_t phaseStep, uint32_t nVFAT)
 {
     req = wisc::RPCMsg("gbt.scanGBTPhases");
 
@@ -22,7 +22,7 @@ DLLEXPORT uint32_t scanGBTPhases(uint32_t *results, uint32_t ohN, uint32_t nScan
         return 1;
     }
 
-    for (unsigned int vfatN = 0; vfatN < NVFAT; vfatN++)
+    for (unsigned int vfatN = 0; vfatN < nVFAT; vfatN++)
     {
         const std::string resultsKey = "OH" + std::to_string(ohN) + ".VFAT" + std::to_string(vfatN);
         if (rsp.get_key_exists(resultsKey)){

--- a/xhalcore/src/common/rpc_manager/optohybrid.cc
+++ b/xhalcore/src/common/rpc_manager/optohybrid.cc
@@ -26,7 +26,7 @@ DLLEXPORT uint32_t broadcastRead(uint32_t ohN, char * regName, uint32_t vfatMask
         return 1;
     }
     else if (rsp.get_key_exists("data")) {
-        const uint32_t size = 24;
+        const uint32_t size = 12; //FIXME: need to get the expected size == nVFATs
         ASSERT(rsp.get_word_array_size("data") == size);
         rsp.get_word_array("data", result);
     } else {
@@ -166,7 +166,7 @@ DLLEXPORT uint32_t getUltraScanResults(uint32_t ohN, uint32_t nevts, uint32_t da
         printf("Caught an error: %s\n", (rsp.get_string("error")).c_str());
         return 1;
     }
-    const uint32_t size = (dacMax - dacMin+1)*24/dacStep;
+    const uint32_t size = (dacMax - dacMin+1)*12/dacStep; //FIXME need to get the expected size == nVFATs
     if (rsp.get_key_exists("data")) {
         ASSERT(rsp.get_word_array_size("data") == size);
         rsp.get_word_array("data", result);

--- a/xhalcore/src/common/rpc_manager/optohybrid.cc
+++ b/xhalcore/src/common/rpc_manager/optohybrid.cc
@@ -1,6 +1,6 @@
 #include "xhal/rpc/optohybrid.h"
 
-DLLEXPORT uint32_t broadcastRead(uint32_t ohN, char * regName, uint32_t vfatMask, uint32_t * result){
+DLLEXPORT uint32_t broadcastRead(uint32_t ohN, char * regName, uint32_t vfatMask, uint32_t * result, uint32_t size){
     /* User supplies the VFAT node name as reg_name, examples:
      *
      *    v2b electronics: reg_name = "VThreshold1" to get VT1
@@ -26,7 +26,6 @@ DLLEXPORT uint32_t broadcastRead(uint32_t ohN, char * regName, uint32_t vfatMask
         return 1;
     }
     else if (rsp.get_key_exists("data")) {
-        const uint32_t size = 12; //FIXME: need to get the expected size == nVFATs
         ASSERT(rsp.get_word_array_size("data") == size);
         rsp.get_word_array("data", result);
     } else {
@@ -146,7 +145,7 @@ DLLEXPORT uint32_t startScanModule(uint32_t ohN, bool useUltra){
     return 0;
 } //End startScanModule(...)
 
-DLLEXPORT uint32_t getUltraScanResults(uint32_t ohN, uint32_t nevts, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep, uint32_t * result){
+DLLEXPORT uint32_t getUltraScanResults(uint32_t ohN, uint32_t nevts, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep, uint32_t * result, uint32_t nvfats){
     req = wisc::RPCMsg("optohybrid.getUltraScanResults");
 
     req.set_word("ohN",ohN);
@@ -166,7 +165,7 @@ DLLEXPORT uint32_t getUltraScanResults(uint32_t ohN, uint32_t nevts, uint32_t da
         printf("Caught an error: %s\n", (rsp.get_string("error")).c_str());
         return 1;
     }
-    const uint32_t size = (dacMax - dacMin+1)*12/dacStep; //FIXME need to get the expected size == nVFATs
+    const uint32_t size = (dacMax - dacMin+1)*nvfats/dacStep; 
     if (rsp.get_key_exists("data")) {
         ASSERT(rsp.get_word_array_size("data") == size);
         rsp.get_word_array("data", result);

--- a/xhalcore/src/common/rpc_manager/vfat3.cc
+++ b/xhalcore/src/common/rpc_manager/vfat3.cc
@@ -64,7 +64,7 @@ DLLEXPORT uint32_t configureVFAT3DacMonitorMultiLink(uint32_t ohMask, uint32_t *
     return 0;
 } //End configureVFAT3DacMonitor(...)
 
-DLLEXPORT uint32_t getChannelRegistersVFAT3(uint32_t ohN, uint32_t vfatMask, uint32_t *chanRegData){
+DLLEXPORT uint32_t getChannelRegistersVFAT3(uint32_t ohN, uint32_t vfatMask, uint32_t *chanRegData, uint32_t nvfats){
     req = wisc::RPCMsg("vfat3.getChannelRegistersVFAT3");
 
     req.set_word("ohN",ohN);
@@ -82,8 +82,7 @@ DLLEXPORT uint32_t getChannelRegistersVFAT3(uint32_t ohN, uint32_t vfatMask, uin
         return 1;
     }
 
-    //const uint32_t size = 3072;
-    const uint32_t size = 1536; //FIXME nChannels depends on the GEM type
+    const uint32_t size = 128*nvfats; // nChannels depends on the GEM type
     if (rsp.get_key_exists("chanRegData")) {
         ASSERT(rsp.get_word_array_size("chanRegData") == size);
         rsp.get_word_array("chanRegData", chanRegData);
@@ -95,7 +94,7 @@ DLLEXPORT uint32_t getChannelRegistersVFAT3(uint32_t ohN, uint32_t vfatMask, uin
     return 0;
 }
 
-DLLEXPORT uint32_t getVFAT3ChipIDs(uint32_t * chipIDData, uint32_t ohN, uint32_t vfatMask, bool rawID)
+DLLEXPORT uint32_t getVFAT3ChipIDs(uint32_t * chipIDData, uint32_t ohN, uint32_t vfatMask, bool rawID, uint32_t nvfats)
 {
     req = wisc::RPCMsg("vfat3.getVFAT3ChipIDs");
 
@@ -116,7 +115,7 @@ DLLEXPORT uint32_t getVFAT3ChipIDs(uint32_t * chipIDData, uint32_t ohN, uint32_t
     }
 
     std::string regBase = "GEM_AMC.OH.OH" + std::to_string(ohN) + ".GEB.VFAT";
-    for(int vfat=0; vfat < 24; ++vfat)
+    for(int vfat=0; vfat < nvfats; ++vfat)
     {
         if((vfatMask >> vfat) & 0x1){
             continue;
@@ -127,7 +126,7 @@ DLLEXPORT uint32_t getVFAT3ChipIDs(uint32_t * chipIDData, uint32_t ohN, uint32_t
     return 0;
 } //End getVFAT3ChipIDs()
 
-DLLEXPORT uint32_t readVFAT3ADC(uint32_t ohN, uint32_t *adcData, bool useExtRefADC, uint32_t vfatMask){
+DLLEXPORT uint32_t readVFAT3ADC(uint32_t ohN, uint32_t *adcData, bool useExtRefADC, uint32_t vfatMask, uint32_t nvfats){
     req = wisc::RPCMsg("vfat3.readVFAT3ADC");
 
     req.set_word("ohN",ohN);
@@ -145,7 +144,8 @@ DLLEXPORT uint32_t readVFAT3ADC(uint32_t ohN, uint32_t *adcData, bool useExtRefA
         return 1;
     }
 
-    const uint32_t size = 24;
+    const uint32_t size = nvfats;
+
     if (rsp.get_key_exists("adcData")) {
         ASSERT(rsp.get_word_array_size("adcData") == size);
         rsp.get_word_array("adcData", adcData);
@@ -157,7 +157,7 @@ DLLEXPORT uint32_t readVFAT3ADC(uint32_t ohN, uint32_t *adcData, bool useExtRefA
     return 0;
 } //End readVFAT3ADC(...)
 
-DLLEXPORT uint32_t readVFAT3ADCMultiLink(uint32_t ohMask, uint32_t *ohVfatMaskArray, uint32_t *adcDataAll, bool useExtRefADC){
+DLLEXPORT uint32_t readVFAT3ADCMultiLink(uint32_t ohMask, uint32_t *ohVfatMaskArray, uint32_t *adcDataAll, bool useExtRefADC, uint32_t nvfats){
     req = wisc::RPCMsg("vfat3.readVFAT3ADCMultiLink");
 
     req.set_word("ohMask",ohMask);
@@ -175,7 +175,7 @@ DLLEXPORT uint32_t readVFAT3ADCMultiLink(uint32_t ohMask, uint32_t *ohVfatMaskAr
         return 1;
     }
 
-    const uint32_t size = 12*24;
+    const uint32_t size = 12*nvfats;
     if (rsp.get_key_exists("adcDataAll")) {
         ASSERT(rsp.get_word_array_size("adcDataAll") == size);
         rsp.get_word_array("adcDataAll", adcDataAll);
@@ -187,26 +187,18 @@ DLLEXPORT uint32_t readVFAT3ADCMultiLink(uint32_t ohMask, uint32_t *ohVfatMaskAr
     return 0;
 } //End readVFAT3ADCMultiLink(...)
 
-DLLEXPORT uint32_t setChannelRegistersVFAT3(uint32_t ohN, uint32_t vfatMask, uint32_t *calEnable, uint32_t *masks, uint32_t *trimARM, uint32_t *trimARMPol, uint32_t *trimZCC, uint32_t *trimZCCPol){
+DLLEXPORT uint32_t setChannelRegistersVFAT3(uint32_t ohN, uint32_t vfatMask, uint32_t *calEnable, uint32_t *masks, uint32_t *trimARM, uint32_t *trimARMPol, uint32_t *trimZCC, uint32_t *trimZCCPol, uint32_t nvfats){
     req = wisc::RPCMsg("vfat3.setChannelRegistersVFAT3");
 
     req.set_word("ohN",ohN);
     req.set_word("vfatMask",vfatMask);
 
-    //req.set_word_array("calEnable",calEnable,3072);
-    //req.set_word_array("masks",masks,3072);
-    //req.set_word_array("trimARM",trimARM,3072);
-    //req.set_word_array("trimARMPol",trimARMPol,3072);
-    //req.set_word_array("trimZCC",trimZCC,3072);
-    //req.set_word_array("trimZCCPol",trimZCCPol,3072);
-
-    //FIXME
-    req.set_word_array("calEnable",calEnable,1536);
-    req.set_word_array("masks",masks,1536);
-    req.set_word_array("trimARM",trimARM,1536);
-    req.set_word_array("trimARMPol",trimARMPol,1536);
-    req.set_word_array("trimZCC",trimZCC,1536);
-    req.set_word_array("trimZCCPol",trimZCCPol,1536);
+    req.set_word_array("calEnable",calEnable,128*nvfats);
+    req.set_word_array("masks",masks,128*nvfats);
+    req.set_word_array("trimARM",trimARM,128*nvfats);
+    req.set_word_array("trimARMPol",trimARMPol,128*nvfats);
+    req.set_word_array("trimZCC",trimZCC,128*nvfats);
+    req.set_word_array("trimZCCPol",trimZCCPol,128*nvfats);
 
 
     wisc::RPCSvc* rpc_loc = getRPCptr();
@@ -224,15 +216,14 @@ DLLEXPORT uint32_t setChannelRegistersVFAT3(uint32_t ohN, uint32_t vfatMask, uin
 }
 
 
-DLLEXPORT uint32_t setChannelRegistersVFAT3Simple(uint32_t ohN, uint32_t vfatMask, uint32_t *chanRegData){
+DLLEXPORT uint32_t setChannelRegistersVFAT3Simple(uint32_t ohN, uint32_t vfatMask, uint32_t *chanRegData, uint32_t nvfats){
     req = wisc::RPCMsg("vfat3.setChannelRegistersVFAT3");
 
     req.set_word("ohN",ohN);
     req.set_word("vfatMask",vfatMask);
     req.set_word("simple",true);
 
-    //req.set_word_array("chanRegData",chanRegData,3072);
-    req.set_word_array("chanRegData",chanRegData,1536); //FIXME
+    req.set_word_array("chanRegData",chanRegData,128*nvfats);
 
     wisc::RPCSvc* rpc_loc = getRPCptr();
 

--- a/xhalcore/src/common/rpc_manager/vfat3.cc
+++ b/xhalcore/src/common/rpc_manager/vfat3.cc
@@ -193,12 +193,21 @@ DLLEXPORT uint32_t setChannelRegistersVFAT3(uint32_t ohN, uint32_t vfatMask, uin
     req.set_word("ohN",ohN);
     req.set_word("vfatMask",vfatMask);
 
-    req.set_word_array("calEnable",calEnable,3072);
-    req.set_word_array("masks",masks,3072);
-    req.set_word_array("trimARM",trimARM,3072);
-    req.set_word_array("trimARMPol",trimARMPol,3072);
-    req.set_word_array("trimZCC",trimZCC,3072);
-    req.set_word_array("trimZCCPol",trimZCCPol,3072);
+    //req.set_word_array("calEnable",calEnable,3072);
+    //req.set_word_array("masks",masks,3072);
+    //req.set_word_array("trimARM",trimARM,3072);
+    //req.set_word_array("trimARMPol",trimARMPol,3072);
+    //req.set_word_array("trimZCC",trimZCC,3072);
+    //req.set_word_array("trimZCCPol",trimZCCPol,3072);
+
+    //FIXME
+    req.set_word_array("calEnable",calEnable,1536);
+    req.set_word_array("masks",masks,1536);
+    req.set_word_array("trimARM",trimARM,1536);
+    req.set_word_array("trimARMPol",trimARMPol,1536);
+    req.set_word_array("trimZCC",trimZCC,1536);
+    req.set_word_array("trimZCCPol",trimZCCPol,1536);
+
 
     wisc::RPCSvc* rpc_loc = getRPCptr();
 
@@ -222,7 +231,8 @@ DLLEXPORT uint32_t setChannelRegistersVFAT3Simple(uint32_t ohN, uint32_t vfatMas
     req.set_word("vfatMask",vfatMask);
     req.set_word("simple",true);
 
-    req.set_word_array("chanRegData",chanRegData,3072);
+    //req.set_word_array("chanRegData",chanRegData,3072);
+    req.set_word_array("chanRegData",chanRegData,1536); //FIXME
 
     wisc::RPCSvc* rpc_loc = getRPCptr();
 

--- a/xhalcore/src/common/rpc_manager/vfat3.cc
+++ b/xhalcore/src/common/rpc_manager/vfat3.cc
@@ -82,7 +82,8 @@ DLLEXPORT uint32_t getChannelRegistersVFAT3(uint32_t ohN, uint32_t vfatMask, uin
         return 1;
     }
 
-    const uint32_t size = 3072;
+    //const uint32_t size = 3072;
+    const uint32_t size = 1536; //FIXME nChannels depends on the GEM type
     if (rsp.get_key_exists("chanRegData")) {
         ASSERT(rsp.get_word_array_size("chanRegData") == size);
         rsp.get_word_array("chanRegData", chanRegData);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Implements GE2/1 compatibility. All new parameters are backed with default values set to GE1/1 defaults. Thus the rest of the software should be able to work unchanged. Requires cms-gem-daq-project/ctp7_modules#132 to work with GE2/1

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
Need to be able to use the current legacy software for GE2/1 integration stand

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested with GE2/1 integration stand.

### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
