### PR TITLE
Add more types to the templated RPC

### DIFF
--- a/xhalcore/include/xhal/rpc/common.h
+++ b/xhalcore/include/xhal/rpc/common.h
@@ -9,7 +9,9 @@
 #define XHAL_RPC_COMMON_H
 
 #include "xhal/rpc/compat.h"
+#include "xhal/rpc/helper.h"
 
+#include <array>
 #include <cstdint>
 #include <string>
 #include <vector>
@@ -111,6 +113,17 @@ namespace xhal { namespace rpc {
          */
         inline void save(const std::vector<std::string> &value) {
             m_wiscMsg->set_string_array(std::to_string(dispenseKey()), value);
+        }
+
+        /*!
+         * \brief Adds a \c std::array<T> to the message where \c T is an integral type (except \c bool)
+         */
+        template<typename T,
+                 std::size_t N,
+                 typename std::enable_if<std::is_integral<T>::value && !helper::is_bool<T>::value, int>::type = 0
+                >
+        inline void save(const std::array<T, N> &value) {
+            m_wiscMsg->set_binarydata(std::to_string(dispenseKey()), value.data(), N*sizeof(T));
         }
 
         /*!
@@ -231,12 +244,23 @@ namespace xhal { namespace rpc {
         /*!
          * \brief Retrieves a \c std::vector<std::string> from the message
          */
-        inline void load(std::vector<std::string> & value) {
+        inline void load(std::vector<std::string> &value) {
             value = m_wiscMsg->get_string_array(std::to_string(dispenseKey()));
         }
 
         /*!
-         * \brief Retrieve a \c T parameter from the message and stores it inside
+         * \brief Retrieves a \c std::array<T> from the message where \c T is an integral type (except \c bool)
+         */
+        template<typename T,
+                 std::size_t N,
+                 typename std::enable_if<std::is_integral<T>::value && !helper::is_bool<T>::value, int>::type = 0
+                >
+        inline void load(std::array<T, N> &value) {
+            m_wiscMsg->get_binarydata(std::to_string(dispenseKey()), value.data(), N*sizeof(T));
+        }
+
+        /*!
+         * \brief Retrieves a \c T parameter from the message and stores it inside
          * a \c void_holder.
          *
          * It should be used when setting the result from a function.

--- a/xhalcore/include/xhal/rpc/common.h
+++ b/xhalcore/include/xhal/rpc/common.h
@@ -443,8 +443,9 @@ namespace xhal { namespace rpc {
      * };
      *
      * // The non-intrusive version allows to serialize objects defined in a library
-     * // Simply define the serialize function in the xhal::rpc namespace with two parameters
-     * // (1) A message (i.e. the serializer or deserializer) and (2) the custom type
+     * // Simply define the serialize function in the xhal::rpc namespace or the namespace
+     * // where the type is defined with two parameters (1) A message (i.e. the serializer
+     * // or deserializer) and (2) the custom type
      * namespace xhal { namspace rpc {
      *     template<typename Message> inline void serialize(Message &msg, Point &point) {
      *         msq & point.x & point.y;
@@ -454,10 +455,11 @@ namespace xhal { namespace rpc {
      *
      * \warning In order to work as intended the \c serialize functions \b MUST modify
      * the object only with the \c operator&
-     *
      */
     template<typename Message, typename T, std::size_t N>
     inline void serialize(Message &msg, std::array<T, N> &value) {
+        // The std::array size is known at compile time (and part of
+        // the signature), so we don't need to serialize it
         for (auto & elem: value) {
             msg & elem;
         }

--- a/xhalcore/include/xhal/rpc/helper.h
+++ b/xhalcore/include/xhal/rpc/helper.h
@@ -13,6 +13,7 @@
 #define XHAL_RPC_HELPER_H
 
 #include <tuple>
+#include <type_traits>
 
 namespace xhal { namespace rpc { namespace helper {
 
@@ -93,6 +94,12 @@ namespace xhal { namespace rpc { namespace helper {
     constexpr inline auto get_forward_as_tuple() {
         return functor_traits<decltype(&Obj::operator())>::forward_as_tuple();
     }
+
+    /*!
+     * \brief Checks whether the template parameter \c T is a \c bool
+     */
+    template <typename T>
+        using is_bool = std::is_same<typename std::decay<T>::type, bool>;
 
     /*!
      * \brief Checks whether the template parameter \c T is a \c std::tuple


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR adds support for new types in the templated RPC methods:

* `std::array<T, N>` where `T` is a serializable type
* `std::map<std::uint32_t, T>` where `T` is a serializable type
* `std::map<std::string, T>` where `T` is a serializable type
* Custom types

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->

This is the continuation of the the [previous PR](https://github.com/cms-gem-daq-project/xhal/pull/121) about the templated RPC methods.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

It has been tested with the help of a dummy CPT7 module (reply with and/or log the method parameter(s)) and a ~10 lines C++ program on the DAQ machine.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
