### PR TITLE
Exception handling in template RPC calls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,28 +3,42 @@ SUBPACKAGES := \
         xhalcore \
         xhalarm
 
-SUBPACKAGES.DEBUG    := $(patsubst %,%.debug,    $(SUBPACKAGES))
-SUBPACKAGES.RPM      := $(patsubst %,%.rpm,      $(SUBPACKAGES))
-SUBPACKAGES.DOC      := $(patsubst %,%.doc,      $(SUBPACKAGES))
-SUBPACKAGES.CLEANRPM := $(patsubst %,%.cleanrpm, $(SUBPACKAGES))
-SUBPACKAGES.CLEANDOC := $(patsubst %,%.cleandoc, $(SUBPACKAGES))
 SUBPACKAGES.CLEAN    := $(patsubst %,%.clean,    $(SUBPACKAGES))
+SUBPACKAGES.DEBUG    := $(patsubst %,%.debug,    $(SUBPACKAGES))
+SUBPACKAGES.INSTALL  := $(patsubst %,%.install,  $(SUBPACKAGES))
+SUBPACKAGES.UNINSTALL:= $(patsubst %,%.uninstall,$(SUBPACKAGES))
+SUBPACKAGES.RPM      := $(patsubst %,%.rpm,      $(SUBPACKAGES))
+SUBPACKAGES.CLEANRPM := $(patsubst %,%.cleanrpm, $(SUBPACKAGES))
+SUBPACKAGES.DOC      := $(patsubst %,%.doc,      $(SUBPACKAGES))
+SUBPACKAGES.CLEANDOC := $(patsubst %,%.cleandoc, $(SUBPACKAGES))
 
-.PHONY: build clean cleanall cleandoc cleanrpm
+.PHONY: $(SUBPACKAGES) \
+	$(SUBPACKAGES.CLEAN) \
+	$(SUBPACKAGES.INSTALL) \
+	$(SUBPACKAGES.UNINSTALL) \
+	$(SUBPACKAGES.RPM) \
+	$(SUBPACKAGES.CLEANRPM) \
+	$(SUBPACKAGES.DOC) \
+	$(SUBPACKAGES.CLEANDOC)
 
+.PHONY: all build clean cleanall cleandoc cleanrpm
 build: $(SUBPACKAGES)
 
-all: $(SUBPACKAGES) $(SUBPACKAGES.RPM) $(SUBPACKAGES.DOC)
+all: $(SUBPACKAGES) $(SUBPACKAGES.DOC)
+
+doc: $(SUBPACKAGES.DOC)
 
 rpm: $(SUBPACKAGES) $(SUBPACKAGES.RPM)
 
-doc: $(SUBPACKAGES.DOC)
+clean: $(SUBPACKAGES.CLEAN)
 
 cleanrpm: $(SUBPACKAGES.CLEANRPM)
 
 cleandoc: $(SUBPACKAGES.CLEANDOC)
 
-clean: $(SUBPACKAGES.CLEAN)
+install: $(SUBPACKAGES) $(SUBPACKAGES.INSTALL)
+
+uninstall: $(SUBPACKAGES.UNINSTALL)
 
 cleanall: clean cleandoc cleanrpm
 
@@ -34,22 +48,30 @@ $(SUBPACKAGES):
 $(SUBPACKAGES.RPM): $(SUBPACKAGES)
 	$(MAKE) -C $(patsubst %.rpm,%, $@) rpm
 
-$(SUBPACKAGES.DOC):
-	$(MAKE) -C $(patsubst %.doc,%, $@) doc
-
-$(SUBPACKAGES.CLEANRPM):
-	$(MAKE) -C $(patsubst %.cleanrpm,%, $@) cleanrpm
+$(SUBPACKAGES.CLEAN):
+	$(MAKE) -C $(patsubst %.clean,%, $@) clean
 
 $(SUBPACKAGES.CLEANDOC):
 	$(MAKE) -C $(patsubst %.cleandoc,%, $@) cleandoc
 
-$(SUBPACKAGES.CLEAN):
-	$(MAKE) -C $(patsubst %.clean,%, $@) clean
+$(SUBPACKAGES.CLEANRPM):
+	$(MAKE) -C $(patsubst %.cleanrpm,%, $@) cleanrpm
 
-.PHONY: $(SUBPACKAGES) $(SUBPACKAGES.INSTALL) $(SUBPACKAGES.CLEAN) $(SUBPACKAGES.DOC) $(SUBPACKAGES.RPM) $(SUBPACKAGES.CLEANRPM) $(SUBPACKAGES.CLEANDOC)
+$(SUBPACKAGES.DOC):
+	$(MAKE) -C $(patsubst %.doc,%, $@) doc
+
+$(SUBPACKAGES.INSTALL): $(SUBPACKAGES)
+	$(MAKE) -C $(patsubst %.install,%, $@) install
+
+$(SUBPACKAGES.UNINSTALL): $(SUBPACKAGES)
+	$(MAKE) -C $(patsubst %.uninstall,%, $@) uninstall
 
 python:
 
 xhalarm:
 
-xhalcore: xhalarm
+xhalcore:
+
+xhalcore.install: xhalarm
+
+xhalcore.rpm: xhalarm

--- a/python/Makefile
+++ b/python/Makefile
@@ -1,24 +1,44 @@
 SUBPACKAGES := \
-        reg_interface_gem \
+        reg_interface_gem
 
+SUBPACKAGES.CLEAN    := $(patsubst %,%.clean,    $(SUBPACKAGES))
 SUBPACKAGES.DEBUG    := $(patsubst %,%.debug,    $(SUBPACKAGES))
-SUBPACKAGES.DOC      := $(patsubst %,%.doc,      $(SUBPACKAGES))
+SUBPACKAGES.INSTALL  := $(patsubst %,%.install,  $(SUBPACKAGES))
+SUBPACKAGES.UNINSTALL:= $(patsubst %,%.uninstall,$(SUBPACKAGES))
 SUBPACKAGES.RPM      := $(patsubst %,%.rpm,      $(SUBPACKAGES))
 SUBPACKAGES.CLEANRPM := $(patsubst %,%.cleanrpm, $(SUBPACKAGES))
+SUBPACKAGES.DOC      := $(patsubst %,%.doc,      $(SUBPACKAGES))
 SUBPACKAGES.CLEANDOC := $(patsubst %,%.cleandoc, $(SUBPACKAGES))
-SUBPACKAGES.CLEAN    := $(patsubst %,%.clean,    $(SUBPACKAGES))
 
-.PHONY: $(SUBPACKAGES) $(SUBPACKAGES.INSTALL) $(SUBPACKAGES.CLEAN) $(SUBPACKAGES.DOC) $(SUBPACKAGES.RPM) $(SUBPACKAGES.CLEANRPM) $(SUBPACKAGES.CLEANDOC)
+.PHONY: $(SUBPACKAGES) \
+	$(SUBPACKAGES.CLEAN) \
+	$(SUBPACKAGES.INSTALL) \
+	$(SUBPACKAGES.UNINSTALL) \
+	$(SUBPACKAGES.RPM) \
+	$(SUBPACKAGES.CLEANRPM) \
+	$(SUBPACKAGES.DOC) \
+	$(SUBPACKAGES.CLEANDOC)
+
+.PHONY: all build clean cleanall cleandoc cleanrpm doc install uninstall rpm
+build: $(SUBPACKAGES)
+
+all: $(SUBPACKAGES) $(SUBPACKAGES.DOC)
 
 rpm: $(SUBPACKAGES) $(SUBPACKAGES.RPM)
 
 doc: $(SUBPACKAGES.DOC)
 
-cleanrpm: $(SUBPACKAGES.CLEANRPM)
-
 clean: $(SUBPACKAGES.CLEAN)
 
 cleandoc: $(SUBPACKAGES.CLEANDOC)
+
+cleanrpm: $(SUBPACKAGES.CLEANRPM)
+
+install: $(SUBPACKAGES.INSTALL)
+
+uninstall: $(SUBPACKAGES.UNINSTALL)
+
+cleanall: clean cleandoc cleanrpm
 
 $(SUBPACKAGES):
 	$(MAKE) -C $@
@@ -26,14 +46,20 @@ $(SUBPACKAGES):
 $(SUBPACKAGES.RPM):
 	$(MAKE) -C $(patsubst %.rpm,%, $@) rpm
 
-$(SUBPACKAGES.DOC):
-	$(MAKE) -C $(patsubst %.doc,%, $@) html
-
-$(SUBPACKAGES.CLEANRPM):
-	$(MAKE) -C $(patsubst %.cleanrpm,%, $@) cleanrpm
+$(SUBPACKAGES.CLEAN):
+	$(MAKE) -C $(patsubst %.clean,%, $@) clean
 
 $(SUBPACKAGES.CLEANDOC):
 	$(MAKE) -C $(patsubst %.cleandoc,%, $@) cleandoc
 
-$(SUBPACKAGES.CLEAN):
-	$(MAKE) -C $(patsubst %.clean,%, $@) clean
+$(SUBPACKAGES.CLEANRPM):
+	$(MAKE) -C $(patsubst %.cleanrpm,%, $@) cleanrpm
+
+$(SUBPACKAGES.DOC):
+	$(MAKE) -C $(patsubst %.doc,%, $@) html
+
+$(SUBPACKAGES.INSTALL):
+	$(MAKE) -C $(patsubst %.install,%, $@) install-site
+
+$(SUBPACKAGES.UNINSTALL):
+	$(MAKE) -C $(patsubst %.uninstall,%, $@) uninstall-site

--- a/python/reg_interface_gem/Makefile
+++ b/python/reg_interface_gem/Makefile
@@ -15,22 +15,22 @@ PackagePath  := $(shell pwd)
 PackageDir   := pkg/$(Namespace)/$(ShortPackage)
 ScriptDir    := pkg/$(Namespace)/scripts
 
+ProjectBase = $(BUILD_HOME)/$(Project)
+ConfigDir   = $(ProjectBase)/config
+
+include $(ConfigDir)/mfCommonDefs.mk
+include $(ConfigDir)/mfPythonDefs.mk
 
 # Explicitly define the modules that are being exported (for PEP420 compliance)
 PythonModules = ["$(Namespace).$(ShortPackage)"]
 $(info PythonModules=${PythonModules})
 
-REG_INTERFACE_GEM_VER_MAJOR:=$(shell $(BUILD_HOME)/$(Project)/config/tag2rel.sh | awk '{split($$0,a," "); print a[1];}' | awk '{split($$0,b,":"); print b[2];}')
-REG_INTERFACE_GEM_VER_MINOR:=$(shell $(BUILD_HOME)/$(Project)/config/tag2rel.sh | awk '{split($$0,a," "); print a[2];}' | awk '{split($$0,b,":"); print b[2];}')
-REG_INTERFACE_GEM_VER_PATCH:=$(shell $(BUILD_HOME)/$(Project)/config/tag2rel.sh | awk '{split($$0,a," "); print a[3];}' | awk '{split($$0,b,":"); print b[2];}')
+include $(ConfigDir)/mfPythonRPM.mk
+include $(ConfigDir)/mfSphinx.mk
 
-include $(BUILD_HOME)/$(Project)/config/mfCommonDefs.mk
-include $(BUILD_HOME)/$(Project)/config/mfPythonDefs.mk
-
-# include $(BUILD_HOME)/$(Project)/config/mfDefs.mk
-
-include $(BUILD_HOME)/$(Project)/config/mfPythonRPM.mk
-include $(BUILD_HOME)/$(Project)/config/mfSphinx.mk
+REG_INTERFACE_GEM_VER_MAJOR:=$(shell $(ConfigDir)/tag2rel.sh | awk '{split($$0,a," "); print a[1];}' | awk '{split($$0,b,":"); print b[2];}')
+REG_INTERFACE_GEM_VER_MINOR:=$(shell $(ConfigDir)/tag2rel.sh | awk '{split($$0,a," "); print a[2];}' | awk '{split($$0,b,":"); print b[2];}')
+REG_INTERFACE_GEM_VER_PATCH:=$(shell $(ConfigDir)/tag2rel.sh | awk '{split($$0,a," "); print a[3];}' | awk '{split($$0,b,":"); print b[2];}')
 
 default:
 	@echo "Running default target"
@@ -39,10 +39,7 @@ default:
 	@cp -rf __init__.py $(PackageDir)
 
 # need to ensure that the python only stuff is packaged into RPMs
-.PHONY: clean preprpm
-_rpmprep: preprpm
-	@echo "Running _rpmprep target"
-preprpm: default
+rpmprep: default
 	@echo "Running preprpm target"
 	$(MakeDir) $(ScriptDir)
 	@cp -rf scripts/*  $(ScriptDir)
@@ -60,11 +57,6 @@ clean:
 	-rm -f  pkg/MANIFEST.in
 	-rm -f  pkg/CHANGELOG.md
 	-rm -f  pkg/requirements.txt
-
-rpm: _rpmall _rpmarm _harvest
-	@echo "Running xhal reg_interface_gem rpm target"
-	find $(RPMBUILD_DIR)/dist -iname "*.rpm" -print0 -exec mv -t $(RPMBUILD_DIR) {} \+
-	find $(RPMBUILD_DIR)/arm -iname "*.rpm" -print0 -exec mv -t $(RPMBUILD_DIR) {} \+
 
 print-env:
 	@echo BUILD_HOME     $(BUILD_HOME)

--- a/xhalarm/Makefile
+++ b/xhalarm/Makefile
@@ -33,6 +33,7 @@ Libraries+=-llog4cplus -lxerces-c -lstdc++
 LDFLAGS+=-shared $(LibraryDirs)
 
 SRCS_XHAL = $(shell echo $(PackageSourceDir)/utils/*.cpp)
+SRCS_XHAL+= $(shell echo $(PackageSourceDir)/rpc/*.cpp)
 
 AUTODEPS_XHAL = $(patsubst $(PackageSourceDir)/%.cpp,$(PackageObjectDir)/%.d,$(SRCS_XHAL))
 

--- a/xhalarm/Makefile
+++ b/xhalarm/Makefile
@@ -9,72 +9,104 @@ PackageDir   := pkg/$(ShortPackage)
 Packager     := Mykhailo Dalchenko
 Arch         := arm
 
-XHAL_VER_MAJOR:=$(shell $(BUILD_HOME)/$(Project)/config/tag2rel.sh | awk '{split($$0,a," "); print a[1];}' | awk '{split($$0,b,":"); print b[2];}')
-XHAL_VER_MINOR:=$(shell $(BUILD_HOME)/$(Project)/config/tag2rel.sh | awk '{split($$0,a," "); print a[2];}' | awk '{split($$0,b,":"); print b[2];}')
-XHAL_VER_PATCH:=$(shell $(BUILD_HOME)/$(Project)/config/tag2rel.sh | awk '{split($$0,a," "); print a[3];}' | awk '{split($$0,b,":"); print b[2];}')
+ProjectPath:= $(BUILD_HOME)/$(Project)
+ConfigDir  := $(ProjectPath)/config
 
-INSTALL_PREFIX=/mnt/persistent/xhal
+include $(ConfigDir)/mfCommonDefs.mk
+include $(ConfigDir)/mfZynq.mk
+include $(ConfigDir)/mfRPMRules.mk
 
-include $(BUILD_HOME)/$(Project)/config/mfCommonDefs.mk
-include $(BUILD_HOME)/$(Project)/config/mfZynq.mk
-include $(BUILD_HOME)/$(Project)/config/mfRPMRules.mk
+PackageSourceDir:=$(ProjectPath)/xhalcore/src/common
+PackageIncludeDir:=$(ProjectPath)/xhalcore/include
 
-ADDFLAGS=-std=gnu++14
+XHAL_VER_MAJOR:=$(shell $(ConfigDir)/tag2rel.sh | awk '{split($$0,a," "); print a[1];}' | awk '{split($$0,b,":"); print b[2];}')
+XHAL_VER_MINOR:=$(shell $(ConfigDir)/tag2rel.sh | awk '{split($$0,a," "); print a[2];}' | awk '{split($$0,b,":"); print b[2];}')
+XHAL_VER_PATCH:=$(shell $(ConfigDir)/tag2rel.sh | awk '{split($$0,a," "); print a[3];}' | awk '{split($$0,b,":"); print b[2];}')
 
-IncludeDirs = $(BUILD_HOME)/$(Project)/xhalcore/include
+ADDFLAGS=-g -std=gnu++14
+
+IncludeDirs+=$(PackageIncludeDir)
 INC=$(IncludeDirs:%=-I%)
 
-Libraries+= -llog4cplus -lxerces-c -lstdc++
+Libraries+=-llog4cplus -lxerces-c -lstdc++
 
 LDFLAGS+=-shared $(LibraryDirs)
 
-SrcLocation =$(BUILD_HOME)/$(Project)/xhalcore/src/common
-SRCS_XHAL   = $(shell echo $(SrcLocation)/utils/*.cpp)
+SRCS_XHAL = $(shell echo $(PackageSourceDir)/utils/*.cpp)
 
-## Place object files in lib/linux?
-ObjLocation = src/linux/$(Arch)
-OBJS_XHAL   = $(patsubst $(SrcLocation)/%,$(ObjLocation)/%, $(SRCS_XHAL:.cpp=.o))
+AUTODEPS_XHAL = $(patsubst $(PackageSourceDir)/%.cpp,$(PackageObjectDir)/%.d,$(SRCS_XHAL))
 
-XHAL_LIB=$(BUILD_HOME)/$(Project)/$(LongPackage)/lib/libxhal.so
+OBJS_XHAL = $(patsubst %.d,%.o,$(AUTODEPS_XHAL))
 
-.PHONY: clean rpc prerpm
+XHAL_LIB = $(PackageLibraryDir)/libxhal.so
+
+TargetLibraries:= xhal
+
+# destination path macro we'll use below
+df = $(PackageObjectDir)/$(*F)
 
 default: build
 	@echo "Running default target"
+#	@cp -rfp $(ProjectPath)/xhalcore/src/common $(PackagePath)/src/
 	$(MakeDir) $(PackageDir)
 
-_rpmprep: preprpm
-	@echo "Running _rpmprep target"
-
-preprpm: default
+rpmprep: default
 	@echo "Running preprpm target"
-	@cp -rf lib $(PackageDir)
+	$(MakeDir) $(PackageDir)/$(Package)
+	@cp -rfp lib include src Makefile $(PackageDir)/$(Package)
+	@cp -rfp $(ProjectPath)/config $(PackageDir)
+	$(MakeDir) $(RPMBUILD_DIR)/SOURCES
+	cd $(PackageDir)/..; \
+	ls -l; \
+	tar cjf $(Project)-$(LongPackage)-$(PACKAGE_FULL_VERSION).tbz2 $(PackageName); \
+	ls -l; \
+	mv $(Project)-$(LongPackage)-$(PACKAGE_FULL_VERSION).tbz2 $(RPMBUILD_DIR)/SOURCES;
 
-build: clean $(XHAL_LIB)
+all: build
 
-_all: clean $(XHAL_LIB) 
+xhal: $(XHAL_LIB)
 
 doc:
 	@echo "TO DO"
 
+## adapted from http://make.mad-scientist.net/papers/advanced-auto-dependency-generation/
+## Generic object creation rule, generate dependencies and use them later
+$(PackageObjectDir)/%.o: $(PackageSourceDir)/%.cpp
+	$(MakeDir) $(@D)
+	$(CC) $(CFLAGS) $(ADDFLAGS) $(INC) -c -MT $@ -MMD -MP -MF $(@D)/$(*F).Td -o $@ $<
+	mv $(@D)/$(*F).Td $(@D)/$(*F).d
+	touch $@
+
+## dummy rule for dependencies
+$(PackageObjectDir)/%.d:
+
+## mark dependencies and objects as not auto-removed
+.PRECIOUS: $(PackageObjectDir)/%.d
+.PRECIOUS: $(PackageObjectDir)/%.o
+
+## Force rule for all target library names
+$(TargetLibraries):
+
 $(XHAL_LIB): $(OBJS_XHAL) 
-	@mkdir -p $(BUILD_HOME)/$(Project)/$(LongPackage)/lib
-	$(CC) $(ADDFLAGS) $(LDFLAGS) -o $@ $^ $(Libraries)
+	$(MakeDir) -p $(@D)
+	$(CC) $(ADDFLAGS) $(LDFLAGS) -shared -Wl,-soname,$(@F) -o $@ $^ $(Libraries)
 
-$(OBJS_XHAL): $(SRCS_XHAL)
-	$(MakeDir) -p $(shell dirname $@)
-	$(CC) $(CFLAGS) $(ADDFLAGS) $(INC) -c -o $@ $<
+## FIXME obsolete? only for xcompiled things?
+# %.o: %.c
+# 	$(CC) -std=gnu99 -c $(CFLAGS) -o $@ $<
+# %.o: %.cc
+# 	$(CXX) -std=c++0x -c $(CFLAGS) -o $@ $<
 
-%.o: %.c
-	$(CC) -std=gnu99 -c $(CFLAGS) -o $@ $<
-%.o: %.cc
-	$(CXX) -std=c++0x -c $(CFLAGS) -o $@ $<
+build: $(TargetLibraries)
 
 clean:
 	-rm -rf $(OBJS_XHAL)
-	-rm -rf $(XHAL_LIB)
-	-rm -rf $(BUILD_HOME)/$(Project)/$(LongPackage)/lib
+	-rm -rf $(PackageLibraryDir)
+	-rm -rf $(PackageExecDir)
 	-rm -rf $(PackageDir)
 
 cleandoc: 
 	@echo "TO DO"
+
+cleanall:
+	-rm -rf $(PackageObjectDir)

--- a/xhalcore/Makefile
+++ b/xhalcore/Makefile
@@ -9,111 +9,127 @@ PackageDir   := pkg/$(ShortPackage)
 Packager     := Mykhailo Dalchenko
 Arch         := x86_64
 
-XHAL_VER_MAJOR:=$(shell $(BUILD_HOME)/$(Project)/config/tag2rel.sh | awk '{split($$0,a," "); print a[1];}' | awk '{split($$0,b,":"); print b[2];}')
-XHAL_VER_MINOR:=$(shell $(BUILD_HOME)/$(Project)/config/tag2rel.sh | awk '{split($$0,a," "); print a[2];}' | awk '{split($$0,b,":"); print b[2];}')
-XHAL_VER_PATCH:=$(shell $(BUILD_HOME)/$(Project)/config/tag2rel.sh | awk '{split($$0,a," "); print a[3];}' | awk '{split($$0,b,":"); print b[2];}')
+ProjectPath:= $(BUILD_HOME)/$(Project)
+ConfigDir  := $(ProjectPath)/config
 
-INSTALL_PREFIX=/opt/xhal
+include $(ConfigDir)/mfCommonDefs.mk
+include $(ConfigDir)/mfPythonDefs.mk
+include $(ConfigDir)/mfRPMRules.mk
 
-include $(BUILD_HOME)/$(Project)/config/mfCommonDefs.mk
-include $(BUILD_HOME)/$(Project)/config/mfPythonDefs.mk
-include $(BUILD_HOME)/$(Project)/config/mfRPMRules.mk
+PackageSourceDir:=$(PackagePath)/src/common
 
-CCFLAGS=-O0 -g3 -fno-inline -Wall -pthread
-ADDFLAGS=-fPIC -std=c++11 -m64
+XHAL_VER_MAJOR:=$(shell $(ConfigDir)/tag2rel.sh | awk '{split($$0,a," "); print a[1];}' | awk '{split($$0,b,":"); print b[2];}')
+XHAL_VER_MINOR:=$(shell $(ConfigDir)/tag2rel.sh | awk '{split($$0,a," "); print a[2];}' | awk '{split($$0,b,":"); print b[2];}')
+XHAL_VER_PATCH:=$(shell $(ConfigDir)/tag2rel.sh | awk '{split($$0,a," "); print a[3];}' | awk '{split($$0,b,":"); print b[2];}')
 
-IncludeDirs+= /opt/xdaq/include
-IncludeDirs+= $(BUILD_HOME)/$(Project)/$(LongPackage)/include
+CCFLAGS=-fno-inline -Wall -pthread
+ADDFLAGS=-g -fPIC -std=c++11 -m64
+
+IncludeDirs+= $(XDAQ_ROOT)/include
+IncludeDirs+= $(PackageIncludeDir)
 INC=$(IncludeDirs:%=-I%)
 
-Libraries+= -llog4cplus -lxerces-c -lwiscrpcsvc -lstdc++
+Libraries+=-llog4cplus -lxerces-c -lwiscrpcsvc -lstdc++
 
-LibraryDirs+=-L/opt/xdaq/lib
+LibraryDirs+=-L$(XDAQ_ROOT)/lib
+LibraryDirs+=-L$(PackageLibraryDir)
 LibraryDirs+=-L/opt/wiscrpcsvc/lib
 
 LDFLAGS = -shared $(LibraryDirs)
 
-SrcLocation  = src/common
-SRCS_UTILS   = $(shell echo $(SrcLocation)/utils/*.cpp)
-SRCS_XHAL    = $(shell echo $(SrcLocation)/*.cpp)
-SRCS_XHALPY  = $(shell echo $(SrcLocation)/python_wrappers/*.cpp)
-SRCS_RPC_MAN = $(shell echo $(SrcLocation)/rpc_manager/*.cpp)
+SRCS_XHAL   = $(wildcard $(PackageSourceDir)/*.cpp)
+SRCS_UTILS  = $(wildcard $(PackageSourceDir)/utils/*.cpp)
+SRCS_XHALPY = $(wildcard $(PackageSourceDir)/python_wrappers/*.cpp)
+SRCS_RPCMAN = $(wildcard $(PackageSourceDir)/rpc_manager/*.cpp)
+# SRCS_EXES     = $(wildcard $(PackageSourceDir)/*.cxx)
+# SRCS_TEST_EXES= $(wildcard $(PackageTestSourceDir)/*.cxx)
 
-## Place object files in src/linux/$(Arch)
-ObjLocation = src/linux/$(Arch)
-OBJS_UTILS   = $(patsubst $(SrcLocation)/%,$(ObjLocation)/%, $(SRCS_UTILS:.cpp=.o))
-OBJS_XHAL    = $(patsubst $(SrcLocation)/%,$(ObjLocation)/%, $(SRCS_XHAL:.cpp=.o))
-OBJS_XHALPY  = $(patsubst $(SrcLocation)/%,$(ObjLocation)/%, $(SRCS_XHALPY:.cpp=.o))
-OBJS_RPC_MAN = $(patsubst $(SrcLocation)/%,$(ObjLocation)/%, $(SRCS_RPC_MAN:.cpp=.o))
+AUTODEPS_XHAL   = $(patsubst $(PackageSourceDir)/%.cpp,$(PackageObjectDir)/%.d,$(SRCS_XHAL))
+AUTODEPS_UTILS  = $(patsubst $(PackageSourceDir)/%.cpp,$(PackageObjectDir)/%.d,$(SRCS_UTILS))
+AUTODEPS_XHALPY = $(patsubst $(PackageSourceDir)/%.cpp,$(PackageObjectDir)/%.d,$(SRCS_XHALPY))
+AUTODEPS_RPCMAN = $(patsubst $(PackageSourceDir)/%.cpp,$(PackageObjectDir)/%.d,$(SRCS_RPCMAN))
 
-XHALCORE_LIB = $(BUILD_HOME)/$(Project)/$(LongPackage)/lib/libxhal.so
-RPC_MAN_LIB  = $(BUILD_HOME)/$(Project)/$(LongPackage)/lib/librpcman.so
-XHALPY_LIB   = $(BUILD_HOME)/$(Project)/$(LongPackage)/lib/xhalpy.so
+OBJS_XHAL   = $(patsubst %.d,%.o,$(AUTODEPS_XHAL))
+OBJS_UTILS  = $(patsubst %.d,%.o,$(AUTODEPS_UTILS))
+OBJS_XHALPY = $(patsubst %.d,%.o,$(AUTODEPS_XHALPY))
+OBJS_RPCMAN = $(patsubst %.d,%.o,$(AUTODEPS_RPCMAN))
 
-.PHONY: clean xhalcore rpc prerpm
+XHAL_LIB   = $(PackageLibraryDir)/libxhal.so
+XHALPY_LIB = $(PackageLibraryDir)/xhalpy.so
+RPCMAN_LIB = $(PackageLibraryDir)/librpcman.so
+
+TargetLibraries:= xhal xhalpy rpcman
+
+# destination path macro we'll use below
+df = $(PackageObjectDir)/$(*F)
+
+.PHONY: xhal rpc
 
 default: build
 	@echo "Running default target"
 	$(MakeDir) $(PackageDir)
 
-_rpmprep: preprpm
-	@echo "Running _rpmprep target"
-
-preprpm: default
+rpmprep: default
 	@echo "Running preprpm target"
 	$(MakeDir) lib/arm
-	@cp -rfp $(BUILD_HOME)/$(Project)/xhalarm/lib/*.so lib/arm
-	@cp -rfp lib $(PackageDir)
+	$(MakeDir) $(PackageDir)/$(Package)
+	@cp -rfp $(ProjectPath)/xhalarm/lib/*.so lib/arm
+	@cp -rfp lib include src Makefile $(PackageDir)/$(Package)
+	@cp -rfp $(ProjectPath)/config $(PackageDir)
+	$(MakeDir) $(RPMBUILD_DIR)/SOURCES
+	cd $(PackageDir)/..; \
+	tar cjf $(RPMBUILD_DIR)/SOURCES/$(Project)-$(LongPackage)-$(PACKAGE_FULL_VERSION).tbz2 $(PackageName);
 
-build: xhalcore rpc
+rpc: xhal $(RPCMAN_LIB)
 
-_all: $(XHALCORE_LIB) $(RPC_MAN_LIB) $(XHALPY_LIB)
+xhal: $(XHAL_LIB)
 
-rpc: xhalcore $(RPC_MAN_LIB)
-
-xhalcore: $(XHALCORE_LIB)
-
-xhalpy: xhalcore rpc $(XHALPY_LIB)
+xhalpy: xhal rpc $(XHALPY_LIB)
 
 doc:
 	@echo "TO DO"
 
-$(OBJS_UTILS): $(SRCS_UTILS)
-	@rm -rf $(OBJS_UTILS)
-	$(MakeDir) $(shell dirname $@)
-	$(CC) $(CCFLAGS) $(ADDFLAGS) $(INC) -c $< -o $@
+## adapted from http://make.mad-scientist.net/papers/advanced-auto-dependency-generation/
+## Generic object creation rule, generate dependencies and use them later
+$(PackageObjectDir)/%.o: $(PackageSourceDir)/%.cpp
+	$(MakeDir) $(@D)
+	$(CXX) $(CCFLAGS) $(ADDFLAGS) $(INC) -c -MT $@ -MMD -MP -MF $(@D)/$(*F).Td -o $@ $<
+	mv $(@D)/$(*F).Td $(@D)/$(*F).d
+	touch $@
 
-$(OBJS_XHAL): $(SRCS_XHAL)
-	$(MakeDir) $(shell dirname $@)
-#	$(CC) $(CCFLAGS) $(ADDFLAGS) $(INC) $(Libraries) -c $(@:%.o=%.cpp) -o $@ 
-	$(CC) $(CCFLAGS) $(ADDFLAGS) $(INC) -c -o $@ $(patsubst $(ObjLocation)/%,$(SrcLocation)/%, $(@:%.o=%.cpp))
+## dummy rule for dependencies
+$(PackageObjectDir)/%.d:
 
-$(OBJS_RPC_MAN): $(SRCS_RPC_MAN)
-	$(MakeDir) $(shell dirname $@)
-#	$(CC) $(CCFLAGS) $(ADDFLAGS) $(INC) $(Libraries) -c $(@:%.o=%.cpp) -o $@ 
-	$(CC) $(CCFLAGS) $(ADDFLAGS) $(INC) -c -o $@ $(patsubst $(ObjLocation)/%,$(SrcLocation)/%, $(@:%.o=%.cpp))
+## mark dependencies and objects as not auto-removed
+.PRECIOUS: $(PackageObjectDir)/%.d
+.PRECIOUS: $(PackageObjectDir)/%.o
 
-$(OBJS_XHALPY):$(SRCS_XHALPY)
-	$(MakeDir) $(shell dirname $@)
-	$(CC) $(CCFLAGS) $(ADDFLAGS) $(INC) -I$(PYTHON_INCLUDE_PREFIX) -c $< -o $@
+## Force rule for all target library names
+$(TargetLibraries):
 
-$(XHALCORE_LIB): $(OBJS_UTILS) $(OBJS_XHAL)
-	$(MakeDir) $(BUILD_HOME)/$(Project)/$(LongPackage)/lib
-	$(CC) $(ADDFLAGS) $(LDFLAGS) -o $@ $^ $(Libraries)
-
-$(RPC_MAN_LIB): $(OBJS_RPC_MAN)
-	$(MakeDir) $(BUILD_HOME)/$(Project)/$(LongPackage)/lib
-	$(CC) $(ADDFLAGS) $(LDFLAGS) -o $@ $^ $(Libraries)
+$(XHAL_LIB): $(OBJS_XHAL) $(OBJS_UTILS)
+	$(MakeDir) -p $(@D)
+	$(CXX) $(ADDFLAGS) $(LDFLAGS) -shared -Wl,-soname,$(@F) -o $@ $^ $(Libraries)
 
 $(XHALPY_LIB): $(OBJS_XHALPY)
-	$(MakeDir) $(BUILD_HOME)/$(Project)/$(LongPackage)/lib
-	$(CC) $(ADDFLAGS) $(LDFLAGS) -L$(PYTHON_LIB_PREFIX) -Llib -o $@ $< $(Libraries) -lboost_python -l$(PYTHON_LIB) -lxhal -lrpcman
+	$(MakeDir) -p $(@D)
+	$(CXX) $(ADDFLAGS) $(LDFLAGS) -L$(PYTHON_LIB_PREFIX) -shared -Wl,-soname,$(@F) -o $@ $^ $(Libraries) -lboost_python -l$(PYTHON_LIB) -lxhal -lrpcman
+
+$(RPCMAN_LIB): $(OBJS_RPCMAN)
+	$(MakeDir) -p $(@D)
+	$(CXX) $(ADDFLAGS) $(LDFLAGS) -shared -Wl,-soname,$(@F) -o $@ $^ $(Libraries)
+
+## xhalcore Compile $(TargetLibraries)
+build: $(TargetLibraries)
 
 clean:
-	-rm -rf $(OBJS_UTILS) $(OBJS_XHAL) $(OBJS_RPC_MAN) $(OBJS_XHALPY)
-	-rm -rf $(XHALCORE_LIB) $(XHALPY_LIB) $(RPC_MAN_LIB)
-	-rm -rf $(BUILD_HOME)/$(Project)/$(LongPackage)/lib
+	-rm -rf $(OBJS_UTILS) $(OBJS_XHAL) $(OBJS_RPCMAN) $(OBJS_XHALPY)
+	-rm -rf $(PackageLibraryDir)
+	-rm -rf $(PackageExecDir)
 	-rm -rf $(PackageDir)
 
 cleandoc: 
 	@echo "TO DO"
+
+cleanall:
+	-rm -rf $(PackageObjectDir)

--- a/xhalcore/Makefile
+++ b/xhalcore/Makefile
@@ -39,6 +39,7 @@ LDFLAGS = -shared $(LibraryDirs)
 
 SRCS_XHAL   = $(wildcard $(PackageSourceDir)/*.cpp)
 SRCS_UTILS  = $(wildcard $(PackageSourceDir)/utils/*.cpp)
+SRCS_UTILS += $(wildcard $(PackageSourceDir)/rpc/*.cpp)
 SRCS_XHALPY = $(wildcard $(PackageSourceDir)/python_wrappers/*.cpp)
 SRCS_RPCMAN = $(wildcard $(PackageSourceDir)/rpc_manager/*.cpp)
 # SRCS_EXES     = $(wildcard $(PackageSourceDir)/*.cxx)

--- a/xhalcore/include/xhal/rpc/exceptions.h
+++ b/xhalcore/include/xhal/rpc/exceptions.h
@@ -57,6 +57,13 @@ namespace xhal { namespace rpc { namespace helper {
      */
     void setExceptionType(wisc::RPCMsg *response);
 
+    /**
+     * \brief Fetches an error message from \c response.
+     *
+     * The \c error key must be set and to a string.
+     */
+    std::string readExceptionMessage(const wisc::RPCMsg &response);
+
 }}} // namespace xhal::rpc::helper
 
 #endif // XHAL_RPC_EXCEPTIONS_H

--- a/xhalcore/include/xhal/rpc/exceptions.h
+++ b/xhalcore/include/xhal/rpc/exceptions.h
@@ -1,0 +1,62 @@
+/*!
+ * \file
+ * \brief This file contains helpers for exception handling.
+ *
+ * \author Louis Moureaux <lmoureau@ulb.ac.be>
+ */
+
+#ifndef XHAL_RPC_EXCEPTIONS_H
+#define XHAL_RPC_EXCEPTIONS_H
+
+#include "xhal/rpc/wiscRPCMsg.h"
+
+namespace xhal { namespace rpc { namespace helper {
+
+    /**
+     * \brief Retrieves a user-friendly message for the given exception.
+     *
+     * Specialization for \c std::exception.
+     */
+    std::string getExceptionMessage(const std::exception &e);
+
+    /**
+     * \brief Retrieves a user-friendly message for the given exception.
+     *
+     * Specialization for \c wisc::RPCMsg::BadKeyException.
+     *
+     * \note This function is never called because the constructor of \c BadKeyException calls
+     *       \c std::abort. It is kept in case the issue is corrected in the future.
+     */
+    std::string getExceptionMessage(const wisc::RPCMsg::BadKeyException &e);
+
+    /**
+     * \brief Retrieves a user-friendly message for the given exception.
+     *
+     * Specialization for \c wisc::RPCMsg::TypeException.
+     */
+    std::string getExceptionMessage(const wisc::RPCMsg::TypeException &e);
+
+    /**
+     * \brief Retrieves a user-friendly message for the given exception.
+     *
+     * Specialization for \c wisc::RPCMsg::BufferTooSmallException.
+     */
+    std::string getExceptionMessage(const wisc::RPCMsg::BufferTooSmallException &e);
+
+    /**
+     * \brief Retrieves a user-friendly message for the given exception.
+     *
+     * Specialization for \c wisc::RPCMsg::CorruptMessageException.
+     */
+    std::string getExceptionMessage(const wisc::RPCMsg::CorruptMessageException &e);
+
+    /**
+     * \brief Sets the type of the current exception in \c response.
+     * \internal This function makes use of low-level functions of the Itanium C++ ABI to
+     *           retrieve the type name of the current exception.
+     */
+    void setExceptionType(wisc::RPCMsg *response);
+
+}}} // namespace xhal::rpc::helper
+
+#endif // XHAL_RPC_EXCEPTIONS_H

--- a/xhalcore/include/xhal/rpc/exceptions.h
+++ b/xhalcore/include/xhal/rpc/exceptions.h
@@ -8,7 +8,7 @@
 #ifndef XHAL_RPC_EXCEPTIONS_H
 #define XHAL_RPC_EXCEPTIONS_H
 
-#include "xhal/rpc/wiscRPCMsg.h"
+#include "xhal/rpc/wiscrpcsvc.h"
 
 namespace xhal { namespace rpc { namespace helper {
 
@@ -49,6 +49,13 @@ namespace xhal { namespace rpc { namespace helper {
      * Specialization for \c wisc::RPCMsg::CorruptMessageException.
      */
     std::string getExceptionMessage(const wisc::RPCMsg::CorruptMessageException &e);
+
+    /**
+     * \brief Retrieves a user-friendly message for the given exception.
+     *
+     * Specialization for \c wisc::RPCSvc::RPCException and derived types.
+     */
+    std::string getExceptionMessage(const wisc::RPCSvc::RPCException &e);
 
     /**
      * \brief Sets the type of the current exception in \c response.

--- a/xhalcore/include/xhal/rpc/register.h
+++ b/xhalcore/include/xhal/rpc/register.h
@@ -7,8 +7,8 @@
  * \author Louis Moureaux <lmoureau@ulb.ac.be>
  */
 
-#ifndef XHAL_RPC_REGSTER_H
-#define XHAL_RPC_REGSTER_H
+#ifndef XHAL_RPC_REGISTER_H
+#define XHAL_RPC_REGISTER_H
 
 #include "xhal/rpc/common.h"
 #include "xhal/rpc/compat.h"

--- a/xhalcore/src/common/rpc/exceptions.cpp
+++ b/xhalcore/src/common/rpc/exceptions.cpp
@@ -49,4 +49,14 @@ namespace xhal { namespace rpc { namespace helper {
         }
     }
 
+    std::string readExceptionMessage(const wisc::RPCMsg &response)
+    {
+        std::string msg = "remote error: ";
+        if (response.get_key_exists(std::string(abiVersion) + ".type")) {
+            msg += response.get_string(std::string(abiVersion) + ".type") + ": ";
+        }
+        msg += response.get_string(std::string(abiVersion) + ".error");
+        return msg;
+    }
+
 }}} // namespace xhal::rpc::helper

--- a/xhalcore/src/common/rpc/exceptions.cpp
+++ b/xhalcore/src/common/rpc/exceptions.cpp
@@ -31,6 +31,11 @@ namespace xhal { namespace rpc { namespace helper {
         return "corrupt RPC message: " + e.reason;
     }
 
+    std::string getExceptionMessage(const wisc::RPCSvc::RPCException &e)
+    {
+        return e.message;
+    }
+
     void setExceptionType(wisc::RPCMsg *response)
     {
         // Fetch the type of the current exception


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Handle exceptions thrown by RPC methods and the Wisconsin RPC library. Turn them into two exceptions types at the calling site. For exceptions thrown on the remote side, a stack trace can be recorded and sent back (optional).

This PR adds a `.cpp` file that should be compiled into its a library. It is required on all architectures. The build system has *not* been modified to include it.

### Example exception info

I triggered an exception by doing `.at(-1)` on a `std::vector`. The message is:
```
remote error: std::out_of_range: vector::_M_range_check: __n (which is 18446744073709551615) >= this->size() (which is 10)
```

*[feature was dropped]*
The backtrace as retrieved from the thrown exception is (relevant frames are 5-7):
```
Stack trace (most recent call last):
#17   Object "[0xffffffffffffffff]", at 0xffffffffffffffff, in 
#16   Object "wiscrpcsvc-server.pc/src/wiscrpcsvc-server.pc-build/rpcsvc", at 0x55b4f5f22249, in _start
#15   Object "/lib/x86_64-linux-gnu/libc.so.6", at 0x7f01aa1fdb96, in __libc_start_main
#14   Object "wiscrpcsvc-server.pc/src/wiscrpcsvc-server.pc-build/rpcsvc", at 0x55b4f5f228c9, in main
#13   Object "wiscrpcsvc-server.pc/src/wiscrpcsvc-server.pc-build/rpcsvc", at 0x55b4f5f22b25, in handle_client_connection(int, sockaddr_in&, unsigned int, int&)
#12   Object "wiscrpcsvc-server.pc/src/wiscrpcsvc-server.pc-build/rpcsvc", at 0x55b4f5f23779, in run_client(int)
#11   Object "wiscrpcsvc-server.pc/src/wiscrpcsvc-server.pc-build/rpcsvc", at 0x55b4f5f25fb5, in ModuleManager::invoke_method(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, wisc::RPCMsg*, wisc::RPCMsg*)
#10   Object "/home/louis/Work/GEM/superbuild/gemsuperbuild/install/pc/usr/lib/rpcmodules/memory.so", at 0x7f01a93a5212, in void xhal::rpc::invoke<Memory::Read, 0>(wisc::RPCMsg const*, wisc::RPCMsg*)
#9    Object "/home/louis/Work/GEM/superbuild/gemsuperbuild/install/pc/usr/lib/rpcmodules/memory.so", at 0x7f01a93a5aad, in xhal::rpc::compat::void_holder<std::vector<unsigned int, std::allocator<unsigned int> > > xhal::rpc::compat::tuple_apply<std::vector<unsigned int, std::allocator<unsigned int> >, Memory::Read, unsigned int, unsigned int, 0>(Memory::Read&&, std::tuple<unsigned int, unsigned int> const&)
#8    Object "/home/louis/Work/GEM/superbuild/gemsuperbuild/install/pc/usr/lib/rpcmodules/memory.so", at 0x7f01a93a674f, in decltype (((forward<Memory::Read>)({parm#1}))((get<0ul>)({parm#2}), (get<1ul>)({parm#2}))) xhal::rpc::compat::tuple_apply_impl<Memory::Read, unsigned int, unsigned int, 0ul, 1ul>(Memory::Read&&, std::tuple<unsigned int, unsigned int> const&, xhal::rpc::compat::index_sequence<0ul, 1ul>)
#7    Object "/home/louis/Work/GEM/superbuild/gemsuperbuild/install/pc/usr/lib/rpcmodules/memory.so", at 0x7f01a93a34ed, in Memory::Read::operator()(unsigned int, unsigned int) const
#6    Object "/home/louis/Work/GEM/superbuild/gemsuperbuild/install/pc/usr/lib/rpcmodules/memory.so", at 0x7f01a93a4a22, in std::vector<unsigned int, std::allocator<unsigned int> >::at(unsigned long)
#5    Object "/home/louis/Work/GEM/superbuild/gemsuperbuild/install/pc/usr/lib/rpcmodules/memory.so", at 0x7f01a93a50d3, in std::vector<unsigned int, std::allocator<unsigned int> >::_M_range_check(unsigned long) const
#4    Object "/usr/lib/x86_64-linux-gnu/libstdc++.so.6", at 0x7f01aa873854, in 
#3    Object "../install/pc/usr/lib/libxhal_rpc.so", at 0x7f01ab4b7a3e, in __cxa_throw
#2    Object "../install/pc/usr/lib/libxhal_rpc.so", at 0x7f01ab4b789d, in xhal::rpc::helper::recordStackTrace()
#1    Object "../install/pc/usr/lib/libxhal_rpc.so", at 0x7f01ab4b834d, in backward::StackTraceImpl<backward::system_tag::linux_tag>::load_here(unsigned long)
#0    Object "../install/pc/usr/lib/libxhal_rpc.so", at 0x7f01ab4b9d15, in unsigned long backward::details::unwind<backward::StackTraceImpl<backward::system_tag::linux_tag>::callback>(backward::StackTraceImpl<backward::system_tag::linux_tag>::callback, unsigned long)
```
Line numbers and even code snippets could be obtained by linking against `libdwarf`

### How it works

Exceptions are caught on the server side (CTP7, in `invoke`) and an error message is generated there. The exact type of the exception is determined using a low-level C++ API (defined by the Itanium ABI). This information is sent back to the caller using the `error` and `type` keys. The `call` function checks for the keys and throws an exception with the relevant information.

In addition, code in the `call` function is now protected against exceptions. Any error coming from the Wisconsin RPC library results in an exception being thrown (a single type is used).

*[feature was dropped]*
The optional stack trace functionality works by inserting a hook in the low-level API used by `throw` statements. More specifically, it overrides `__cxa_throw` (also from the Itanium ABI) to record a stack trace every time an exception is thrown. When an exception is caught in `invoke`, the stack trace is queried and sent back to the caller.

Since recording a stack trace for every exception adds some overhead, it is made optional using a preprocessor macro. If `NDEBUG` is set when `register.h` is included, no trace will be recorded. (I'm not sure whether this applies at the level of a module, a compilation unit or even the part of it after the `#include`. This would need to be tested.)

### CTP7 warning

*[feature was dropped, irrelevant]*
The version of `libstdcxx` on the CTP7 has a bug that prevents getting a stack trace. It also fools `gdb`. The best option seems to ask Wisconsin for an image based on a more recent Petalinux. We could also provide an updated version of `libstdcxx` to `LD_PRELOAD` when starting `wiscrpcsvc`, or a tiny library that would only patch the buggy function.

The code was tested primarily on x86, with some testing on a more recent ARM Linux.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
We want to catch exceptions thrown by RPC modules, and provide devs with as much debugging information as possible.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
All prototyping was done on x86. Testing on ARM (CTP7 and another chip) was performed to check for architecture-dependent issues. This polished version was tested on x86.

The following client was used with an RPC-ified `memory`:
```C++
#include "memory.h"

#include <iomanip>
#include <iostream>

#include "xhal/rpc/call.h"

int main(int argc, char **argv)
{
    try
    {
        wisc::RPCSvc conn;
        conn.connect("localhost");

        conn.load_module("memory", "memory v1.0.1");

        auto mem = xhal::rpc::call<Memory::Read>(conn, 0, 10);
        std::cout << std::hex;
        for (std::uint32_t word : mem) {
            std::cout << " " << word;
        }
        std::cout << std::endl;
    }
    catch(const xhal::rpc::RemoteException &e)
    {
        std::cerr << "Remote call failed: " << e.what() << std::endl;
        if (e.hasTrace()) {
            std::cerr << e.trace() << std::endl;
        }
        return 1;
    }
    catch(const xhal::rpc::MessageException &e)
    {
        std::cerr << "Remote call failed: " << e.what() << std::endl;
        return 1;
    }

    return 0;
}
```

Compilation was tested on `gem904daq01` with the Xilinx SDK 2016.2.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
