### PR TITLE
[New Feature] variable waitTime for parallel sbitrate scans

### DIFF
--- a/xhalcore/include/xhal/rpc/calibration_routines.h
+++ b/xhalcore/include/xhal/rpc/calibration_routines.h
@@ -44,7 +44,7 @@ DLLEXPORT uint32_t genScan(uint32_t nevts, uint32_t ohN, uint32_t dacMin, uint32
         uint32_t ch, bool useCalPulse, bool currentPulse, uint32_t calScaleFactor, uint32_t mask, char * scanReg, bool useUltra, bool useExtTrig,
         uint32_t * result, uint32_t nvfats=24);
 DLLEXPORT uint32_t genChannelScan(uint32_t nevts, uint32_t ohN, uint32_t mask, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep, bool useCalPulse, bool currentPulse, uint32_t calScaleFactor, bool useExtTrig, char * scanReg, bool useUltra, uint32_t * result, uint32_t nvfats=24);
-DLLEXPORT uint32_t sbitRateScan(uint32_t ohMask, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep, uint32_t ch,
+DLLEXPORT uint32_t sbitRateScan(uint32_t ohMask, uint32_t waitTime, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep, uint32_t ch,
         char * scanReg, uint32_t * resultDacVal, uint32_t * resultTrigRate, uint32_t * resultTrigRatePerVFAT, uint32_t nvfats=24);
 DLLEXPORT uint32_t ttcGenConf(uint32_t ohN, uint32_t mode, uint32_t type, uint32_t pulseDelay,
         uint32_t L1Ainterval, uint32_t nPulses, bool enable);

--- a/xhalcore/include/xhal/rpc/calibration_routines.h
+++ b/xhalcore/include/xhal/rpc/calibration_routines.h
@@ -44,8 +44,8 @@ DLLEXPORT uint32_t genScan(uint32_t nevts, uint32_t ohN, uint32_t dacMin, uint32
         uint32_t ch, bool useCalPulse, bool currentPulse, uint32_t calScaleFactor, uint32_t mask, char * scanReg, bool useUltra, bool useExtTrig,
         uint32_t * result, uint32_t nvfats=24);
 DLLEXPORT uint32_t genChannelScan(uint32_t nevts, uint32_t ohN, uint32_t mask, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep, bool useCalPulse, bool currentPulse, uint32_t calScaleFactor, bool useExtTrig, char * scanReg, bool useUltra, uint32_t * result, uint32_t nvfats=24);
-DLLEXPORT uint32_t sbitRateScan(uint32_t ohMask, uint32_t waitTime, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep, uint32_t ch,
-        char * scanReg, uint32_t * resultDacVal, uint32_t * resultTrigRate, uint32_t * resultTrigRatePerVFAT, uint32_t nvfats=24);
+DLLEXPORT uint32_t sbitRateScan(uint32_t ohMask, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep, uint32_t ch, char * scanReg,
+                                uint32_t * resultDacVal, uint32_t * resultTrigRate, uint32_t * resultTrigRatePerVFAT, uint32_t nvfats=24, uint32_t waitTime = 1);
 DLLEXPORT uint32_t ttcGenConf(uint32_t ohN, uint32_t mode, uint32_t type, uint32_t pulseDelay,
         uint32_t L1Ainterval, uint32_t nPulses, bool enable);
 DLLEXPORT uint32_t ttcGenToggle(uint32_t ohN, bool enable);

--- a/xhalcore/src/common/rpc_manager/calibration_routines.cc
+++ b/xhalcore/src/common/rpc_manager/calibration_routines.cc
@@ -252,7 +252,7 @@ DLLEXPORT uint32_t genChannelScan(uint32_t nevts, uint32_t ohN, uint32_t mask, u
     return 0;
 } //End genChannelScan()
 
-DLLEXPORT uint32_t sbitRateScan(uint32_t ohMask, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep, uint32_t ch, char * scanReg, uint32_t * resultDacVal, uint32_t * resultTrigRate, uint32_t * resultTrigRatePerVFAT, uint32_t nvfats)
+DLLEXPORT uint32_t sbitRateScan(uint32_t ohMask, uint32_t waitTime, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep, uint32_t ch, char * scanReg, uint32_t * resultDacVal, uint32_t * resultTrigRate, uint32_t * resultTrigRatePerVFAT, uint32_t nvfats)
 {
     req = wisc::RPCMsg("calibration_routines.sbitRateScan");
 
@@ -261,6 +261,7 @@ DLLEXPORT uint32_t sbitRateScan(uint32_t ohMask, uint32_t dacMin, uint32_t dacMa
     req.set_word("dacStep", dacStep);
     req.set_word("ch", ch);
     req.set_word("ohMask", ohMask);
+    req.set_word("waitTime", waitTime);    
     req.set_string("scanReg", std::string(scanReg));
 
     wisc::RPCSvc* rpc_loc = getRPCptr();

--- a/xhalcore/src/common/rpc_manager/calibration_routines.cc
+++ b/xhalcore/src/common/rpc_manager/calibration_routines.cc
@@ -252,7 +252,7 @@ DLLEXPORT uint32_t genChannelScan(uint32_t nevts, uint32_t ohN, uint32_t mask, u
     return 0;
 } //End genChannelScan()
 
-DLLEXPORT uint32_t sbitRateScan(uint32_t ohMask, uint32_t waitTime, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep, uint32_t ch, char * scanReg, uint32_t * resultDacVal, uint32_t * resultTrigRate, uint32_t * resultTrigRatePerVFAT, uint32_t nvfats)
+DLLEXPORT uint32_t sbitRateScan(uint32_t ohMask, uint32_t dacMin, uint32_t dacMax, uint32_t dacStep, uint32_t ch, char * scanReg, uint32_t * resultDacVal, uint32_t * resultTrigRate, uint32_t * resultTrigRatePerVFAT, uint32_t nvfats, uint32_t waitTime)
 {
     req = wisc::RPCMsg("calibration_routines.sbitRateScan");
 


### PR DESCRIPTION
This is one of four pull requests to four repositories that make the data collection time for parallel sbitrate scans configurable.

## Description
Adds `waitTime` argument and sends this argument in the rpc call.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
This was requested in https://github.com/cms-gem-daq-project/ctp7_modules/issues/154

## How Has This Been Tested?
Yes, I performed an sbitThresh scan with the waitTime set to 1000 and the waitTime set to 10000, and found the rates were very close while the second scan took around 10 times longer.

### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
