### PR TITLE
Fix compilation issues in the updated build system

### DIFF
--- a/xhal/src/client/XHALDevice.cpp
+++ b/xhal/src/client/XHALDevice.cpp
@@ -1,5 +1,7 @@
 #include "xhal/client/XHALDevice.h"
 
+#include <string>
+
 xhal::client::XHALDevice::XHALDevice(const std::string& board_domain_name, const std::string& address_table_filename) :
   xhal::client::XHALInterface(board_domain_name),
   m_address_table_filename(address_table_filename)
@@ -62,7 +64,7 @@ uint32_t xhal::client::XHALDevice::readReg(std::string regName)
     return result;
   } else {
     XHAL_ERROR("Register not found in address table!");
-    throw xhal::common::utils::XHALXMLParserException(strcat("XHAL XML exception: can't find node", regName.c_str()));
+    throw xhal::common::utils::XHALXMLParserException(std::string("XHAL XML exception: can't find node") + regName);
   }
 }
 
@@ -140,7 +142,7 @@ void xhal::client::XHALDevice::writeReg(std::string regName, uint32_t value)
     }
   } else {
     XHAL_ERROR("Register not found in address table!");
-    throw xhal::common::utils::XHALXMLParserException(strcat("XHAL XML exception: can't find node", regName.c_str()));
+    throw xhal::common::utils::XHALXMLParserException(std::string("XHAL XML exception: can't find node") + regName);
   }
 }
 

--- a/xhal/src/client/XHALInterface.cpp
+++ b/xhal/src/client/XHALInterface.cpp
@@ -1,5 +1,7 @@
 #include "xhal/client/XHALInterface.h"
 
+#include <log4cplus/version.h>
+
 int xhal::client::XHALInterface::index = 0;
 
 xhal::client::XHALInterface::XHALInterface(const std::string& board_domain_name) :
@@ -7,8 +9,11 @@ xhal::client::XHALInterface::XHALInterface(const std::string& board_domain_name)
   isConnected(false)
 {
   log4cplus::SharedAppenderPtr myAppender(new log4cplus::ConsoleAppender());
-  std::auto_ptr<log4cplus::Layout> myLayout = std::auto_ptr<log4cplus::Layout>(new log4cplus::TTCCLayout());
-  myAppender->setLayout( myLayout );
+#if LOG4CPLUS_VERSION < LOG4CPLUS_MAKE_VERSION(2, 0, 0)
+  myAppender->setLayout(std::auto_ptr<log4cplus::Layout>(new log4cplus::TTCCLayout()));
+#else
+  myAppender->setLayout(std::unique_ptr<log4cplus::Layout>(new log4cplus::TTCCLayout()));
+#endif
   // Following strange construction is required because it looks like log4cplus was compiled withot c++11 support...
   auto t_logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("XHALInterface_"+m_board_domain_name + "_" + std::to_string(index)));
   ++index;

--- a/xhal/src/common/utils/XHALXMLParser.cpp
+++ b/xhal/src/common/utils/XHALXMLParser.cpp
@@ -1,13 +1,18 @@
 #include "xhal/common/utils/XHALXMLParser.h"
 
+#include <log4cplus/version.h>
+
 int xhal::common::utils::XHALXMLParser::index = 0;
 
 xhal::common::utils::XHALXMLParser::XHALXMLParser(const std::string& xmlFile)
 {
   m_xmlFile = xmlFile;
   log4cplus::SharedAppenderPtr myAppender(new log4cplus::ConsoleAppender());
-  std::auto_ptr<log4cplus::Layout> myLayout = std::auto_ptr<log4cplus::Layout>(new log4cplus::TTCCLayout());
-  myAppender->setLayout( myLayout );
+#if LOG4CPLUS_VERSION < LOG4CPLUS_MAKE_VERSION(2, 0, 0)
+  myAppender->setLayout(std::auto_ptr<log4cplus::Layout>(new log4cplus::TTCCLayout()));
+#else
+  myAppender->setLayout(std::unique_ptr<log4cplus::Layout>(new log4cplus::TTCCLayout()));
+#endif
   auto t_logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("XHALXMLParser_" + std::to_string(index)));
   ++index;
   m_logger = t_logger;

--- a/xhal/xhal.mk
+++ b/xhal/xhal.mk
@@ -18,10 +18,10 @@ include $(ConfigDir)/mfCommonDefs.mk
 ifeq ($(Arch),x86_64)
 include $(ConfigDir)/mfPythonDefs.mk
 CFLAGS=-Wall -pthread
-ADDFLAGS=-fPIC -std=c++11 -std=gnu++11 -m64
+ADDFLAGS=-fPIC -std=c++14 -m64
 else
 include $(ConfigDir)/mfZynq.mk
-ADDFLAGS=-std=gnu++14
+ADDFLAGS=-std=c++14
 endif
 
 ADDFLAGS+=$(OPTFLAGS)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

(Supersedes #137)

## Description
<!--- Describe your changes in detail -->

Fixes all compilation issues in the updated build system up to the point where all RPM packages can be built seamlessly on `gem904daq04`. Further runtime tests are going to be performed in order to check the functionalities.

The changes are the following:
* Update the `config` submodule in order to get the new `PETA_PATH` environment variable;
* Cherry-pick the commits from https://github.com/cms-gem-daq-project/xhal/pull/117;
* Compile against C++14 for the return type deduction support;
* Fix a warning message in order to prevent memory corruption.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->

Compile the templated RPC framework with the updated build system.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

All RPM packages can be built out-of-the box on `gem904daq04`.