### PR TITLE
Implement new (de)serializers for the RPC calls

### DIFF
--- a/xhal/include/xhal/common/rpc/common.h
+++ b/xhal/include/xhal/common/rpc/common.h
@@ -13,6 +13,7 @@
 
 #include <array>
 #include <cstdint>
+#include <cstring>
 #include <map>
 #include <string>
 #include <utility>
@@ -586,6 +587,25 @@ namespace xhal {
         std::uint32_t tmp;
         msg >> tmp;
         value = tmp;
+      }
+
+      /**
+       * @brief (De)serializer for the @float type
+       *
+       * Works only if @sizeof(float) is 4 and the representation 
+       * is the same on the client and the server.
+       */
+      template<typename Message>
+      inline void save(Message &msg, const float &value) {
+        std::uint32_t tmp;
+        std::memcpy(&tmp, &value, sizeof(std::uint32_t));
+        msg << tmp;
+      }
+      template<typename Message>
+      inline void load(Message &msg, float &value) {
+        std::uint32_t tmp;
+        msg >> tmp;
+        std::memcpy(&value, &tmp, sizeof(float));
       }
 
     }

--- a/xhal/include/xhal/common/rpc/common.h
+++ b/xhal/include/xhal/common/rpc/common.h
@@ -548,6 +548,22 @@ namespace xhal {
       }
 
       /**
+       * @brief (De)serializer for @c std::vector<T> where @c T is a (de)serializable type
+       */
+      template<typename Message, typename T>
+      inline void serialize(Message &msg, std::vector<T> &value) {
+        // 1. Store or retrieve the vector length
+        std::uint32_t length = value.size(); // no-op during deserialization
+        msg & length;
+        value.resize(length); // no-op during serialization
+
+        // 2. Store or retrieve the vector elements
+        for (std::uint32_t i = 0; i < length; ++i) {
+          msg & value[i];
+        }
+      }
+
+      /**
        * @brief (De)serializer for @c bool
        */
       template<typename Message>

--- a/xhal/include/xhal/common/rpc/common.h
+++ b/xhal/include/xhal/common/rpc/common.h
@@ -14,6 +14,7 @@
 #include <array>
 #include <cstdint>
 #include <cstring>
+#include <limits>
 #include <map>
 #include <string>
 #include <utility>
@@ -613,12 +614,20 @@ namespace xhal {
        */
       template<typename Message>
       inline void save(Message &msg, const float &value) {
+        // This serializer works only for IEEE 754 floating point numbers
+        static_assert(std::numeric_limits<float>::is_iec559,
+                      "Floating point representation not supported by the serializer.");
+
         std::uint32_t tmp;
         std::memcpy(&tmp, &value, sizeof(std::uint32_t));
         msg << tmp;
       }
       template<typename Message>
       inline void load(Message &msg, float &value) {
+        // This deserializer works only for IEEE 754 floating point numbers
+        static_assert(std::numeric_limits<float>::is_iec559,
+                      "Floating point representation not supported by the deserializer.");
+
         std::uint32_t tmp;
         msg >> tmp;
         std::memcpy(&value, &tmp, sizeof(float));

--- a/xhal/include/xhal/common/rpc/common.h
+++ b/xhal/include/xhal/common/rpc/common.h
@@ -545,6 +545,49 @@ namespace xhal {
           msg & elem;
         }
       }
+
+      /**
+       * @brief (De)serializer for @c bool
+       */
+      template<typename Message>
+      inline void save(Message &msg, const bool &value) {
+        msg << static_cast<std::uint32_t>(value);
+      }
+      template<typename Message>
+      inline void load(Message &msg, bool &value) {
+        std::uint32_t tmp;
+        msg >> tmp;
+        value = tmp;
+      }
+
+      /**
+       * @brief (De)serializer for @c std::uint8_t
+       */
+      template<typename Message>
+      inline void save(Message &msg, const std::uint8_t &value) {
+        msg << static_cast<std::uint32_t>(value);
+      }
+      template<typename Message>
+      inline void load(Message &msg, std::uint8_t &value) {
+        std::uint32_t tmp;
+        msg >> tmp;
+        value = tmp;
+      }
+
+      /**
+       * @brief (De)serializer for @c std::uint16_t
+       */
+      template<typename Message>
+      inline void save(Message &msg, const std::uint16_t &value) {
+        msg << static_cast<std::uint32_t>(value);
+      }
+      template<typename Message>
+      inline void load(Message &msg, std::uint16_t &value) {
+        std::uint32_t tmp;
+        msg >> tmp;
+        value = tmp;
+      }
+
     }
   }
 }

--- a/xhal/include/xhal/common/rpc/helper.h
+++ b/xhal/include/xhal/common/rpc/helper.h
@@ -127,6 +127,50 @@ namespace xhal {
         template<typename T>
         using is_tuple = is_tuple_impl<typename std::decay<T>::type>;
 
+        /**
+         * @brief Defines the @c is_func_present class which allows to check the existence of @func
+         *
+         * The function parameter types are given as the @c Args templated arguments while the
+         * lookup result is available in the member @c value.
+         *
+         * \details
+         *
+         * Internally the class work as follow.
+         *
+         * Two overloads of the @c test function are defined. The first one always returns the @no
+         * type while the second one return the type which would be returned if func(Args...) was
+         * called.
+         *
+         * As per SFINAE, the second function is not considered if the func(Args...) does not
+         * exist. Whether func(Args...) exists is as simple as checking the return type of
+         * test<AArgs...>.
+         *
+         * When both overloads exist (i.e. func(Args...) exists), the second overload is prefered
+         * because the argument @c 0  matches better @c int than @c ...
+         */
+        #define XHAL_COMMON_RPC_HELPER_FUNCTION_PRESENT(func)                                 \
+        template <typename... Args>                                                           \
+        class is_##func##_present                                                             \
+        {                                                                                     \
+          struct no {};                                                                       \
+                                                                                              \
+          template <typename... AArgs>                                                        \
+          static no test(...);                                                                \
+                                                                                              \
+          template <typename... AArgs>                                                        \
+          static decltype(func(std::declval<AArgs&>()...)) test(int);                         \
+                                                                                              \
+        public:                                                                               \
+                                                                                              \
+          static constexpr bool value = !std::is_same<no, decltype(test<Args...>(0))>::value; \
+        };
+
+        XHAL_COMMON_RPC_HELPER_FUNCTION_PRESENT(serialize)
+        XHAL_COMMON_RPC_HELPER_FUNCTION_PRESENT(save)
+        XHAL_COMMON_RPC_HELPER_FUNCTION_PRESENT(load)
+
+        #undef XHAL_COMMON_RPC_HELPER_FUNCTION_PRESENT
+
       }
     }
   }

--- a/xhal/xhal.mk
+++ b/xhal/xhal.mk
@@ -37,13 +37,15 @@ XHAL_VER_MAJOR:=$(shell $(ConfigDir)/tag2rel.sh | awk '{split($$0,a," "); print 
 XHAL_VER_MINOR:=$(shell $(ConfigDir)/tag2rel.sh | awk '{split($$0,a," "); print a[2];}' | awk '{split($$0,b,":"); print b[2];}')
 XHAL_VER_PATCH:=$(shell $(ConfigDir)/tag2rel.sh | awk '{split($$0,a," "); print a[3];}' | awk '{split($$0,b,":"); print b[2];}')
 
-IncludeDirs+= $(XDAQ_ROOT)/include
 IncludeDirs+= $(PackageIncludeDir)
 IncludeDirs+= $(PackageIncludeDir)/xhal/extern
-INC=$(IncludeDirs:%=-I%)
 
 Libraries+=-llog4cplus -lxerces-c -lstdc++
+LibraryDirs+=$(PackageLibraryDir)
+
 ifeq ($(Arch),x86_64)
+IncludeDirs+= $(XDAQ_ROOT)/include
+
 Libraries+=-lwiscrpcsvc
 LibraryDirs+=$(XDAQ_ROOT)/lib
 LibraryDirs+=$(WISCRPC_ROOT)/lib
@@ -51,8 +53,7 @@ else
 
 endif
 
-LibraryDirs+=$(PackageLibraryDir)
-
+INC=$(IncludeDirs:%=-I%)
 LDFLAGS+=$(LibraryDirs:%=-L%)
 
 SRCS_XHAL   = $(wildcard $(PackageSourceDir)/common/utils/*.cpp)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR mainly introduces default new type (de)serializers for the templated RPC calls. In order to fix #138, the following additional types are now supported:

* `bool`;
* `std::uint8_t`;
* `std::uin16_t`;
* `float`;
* `std::vector<T>` where `T` is a (de)serializable type.

To get the best support, split (de)serializers can now be created with the names `save` and `load`. Please refer to the documentation and commit message for more information.

Compilation has also been fixed. Previously, the xDAQ headers for the DAQ machine were searched for during compilation for the CTP7, leading to un-resolvable symbols at run-time.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->

See https://github.com/cms-gem-daq-project/xhal/issues/138; used in https://github.com/cms-gem-daq-project/ctp7_modules/pull/169.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Works with https://github.com/cms-gem-daq-project/ctp7_modules/pull/169. More thorough tests should be perform in the future.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
