### PR TITLE
Fix RPC calls with non-reference type parameters

### DIFF
--- a/xhal/include/xhal/common/rpc/helper.h
+++ b/xhal/include/xhal/common/rpc/helper.h
@@ -47,7 +47,7 @@ namespace xhal {
           using decay_args_type = std::tuple<typename std::decay<Args>::type...>;
 
           static constexpr inline auto forward_as_tuple() {
-            return [](Args&&... args){ return std::forward_as_tuple(args...); };
+            return [](const Args&... args){ return std::forward_as_tuple(args...); };
           }
         };
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
[Bug reported by @mexanick]

Before this fix, it was impossible to use the RPC method calls with lvalues if the RPC method parameter type was not a lvalue reference, e.g.

``` bash
/home/mdalchen/cms-gem-daq-project/cmsgemos/gemhardware/devices/src/common/amc/HwGenericAMC.cc:270:120:   required from here
/opt/xhal/include/xhal/common/rpc/call.h:124:58: error: no match for call to ‘(xhal::common::rpc::helper::functor_traits<R (Obj::*)(Args ...) const>::forward_as_tuple() [with Obj = amc::daq::configureDAQModule; R = void; Args = {bool, unsigned int, bool, bool, bool}]::<lambda(bool&&, unsigned int&&, bool&&, bool&&, bool&&)>) (bool&, const unsigned int&, bool&, bool&, bool&)’
           query << helper::get_forward_as_tuple<Method>()(args...);
                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~
/opt/xhal/include/xhal/common/rpc/call.h:124:58: note: candidate: ‘std::tuple<bool&, unsigned int&, bool&, bool&, bool&> (*)(bool&&, unsigned int&&, bool&&, bool&&, bool&&)’ <conversion>
/opt/xhal/include/xhal/common/rpc/call.h:124:58: note:   conversion of argument 6 would be ill-formed:
/opt/xhal/include/xhal/common/rpc/call.h:124:58: error: cannot bind rvalue reference of type ‘bool&&’ to lvalue of type ‘bool’
```

As described in the commit message, the following change has been made to fix the issue. The RPC method calls should now be as close as possible from a real local function call.

> The helper::functor_traits::foward_as_tuple function returns a lambda
function taking the Args&&... argument types (where Args... are the RPC
method argument types). Contrarily to what was expected, the perfect
forwarding template argument syntax only works for deduced arguments,
the compiler needs to know whether the variable is a lvalue or rvalue.
> 
> Since the lambda argument types are not deduced, the following happened:
> 
> * When a reference type was used for the RPC parameter, & collapsed with
  && into &, a lvalue reference.
> * When a non-reference type was used for the RPC parameter, the
  "collapsed" was directly &&, a rvalue reference.
> 
> The solution consists in making sure that all values are captured by
constant lvalue reference in the lambda parameter. The compiler should be
able to optimize the binary as well as before the fix.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->

Widely use the templated RPC calls.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Can successfully use this (slightly modified) RPC method:

``` c++
struct getVFAT3ChipIDs : public xhal::common::rpc::Method
{
    std::vector<uint32_t> operator()(const uint16_t ohN, const uint32_t vfatMask=0xff000000, bool rawID=false) const;
};
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
